### PR TITLE
Revert "fix: Insert in cache only used elements (#7)"

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/StoreEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/StoreEntitySupplier.kt
@@ -1,8 +1,8 @@
 package com.github.rushyverse.core.supplier.database
 
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onEmpty
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toSet
 import java.util.*
 
 /**
@@ -34,11 +34,9 @@ class StoreEntitySupplier(
     }
 
     override suspend fun getFriends(uuid: UUID): Flow<UUID> {
-        return supplier.getFriends(uuid).onEach {
-            cache.addFriend(uuid, it)
-        }.onEmpty {
-            cache.setFriends(uuid, emptySet())
-        }
+        val friends = supplier.getFriends(uuid).toSet()
+        cache.setFriends(uuid, friends)
+        return friends.asFlow()
     }
 
     override suspend fun isFriend(uuid: UUID, friend: UUID): Boolean {

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/StoreEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/StoreEntitySupplierTest.kt
@@ -4,7 +4,9 @@ import com.github.rushyverse.core.utils.getRandomString
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Nested
 import java.util.*
@@ -130,56 +132,11 @@ class StoreEntitySupplierTest {
             val id = UUID.randomUUID()
             val friends = List(5) { UUID.randomUUID() }
             coEvery { supplier.getFriends(id) } returns friends.asFlow()
-            coEvery { cache.addFriend(id, any()) } returns true
+            coEvery { cache.setFriends(id, any()) } returns true
 
             assertEquals(friends, entitySupplier.getFriends(id).toList())
             coVerify(exactly = 1) { supplier.getFriends(id) }
-
-            friends.forEach {
-                coVerify(exactly = 1) { cache.addFriend(id, it) }
-            }
-        }
-
-        @Test
-        fun `should store partial list of friends if flow is half used`() = runTest {
-            val id = UUID.randomUUID()
-            val friends = List(5) { UUID.randomUUID() }
-            val used = friends.take(3)
-            coEvery { supplier.getFriends(id) } returns friends.asFlow()
-            coEvery { cache.addFriend(id, any()) } returns true
-
-            assertEquals(used, entitySupplier.getFriends(id).take(used.size).toList())
-            coVerify(exactly = 1) { supplier.getFriends(id) }
-
-            used.forEach {
-                coVerify(exactly = 1) { cache.addFriend(id, it) }
-            }
-
-            friends.takeLast(2).forEach {
-                coVerify(exactly = 0) { cache.addFriend(id, it) }
-            }
-        }
-
-        @Test
-        fun `should store partial list of friends if flow is half used filtred`() = runTest {
-            val id = UUID.randomUUID()
-            val friends = listOf(
-                UUID.fromString("148b4856-504d-44aa-895d-19988dee62d0"),
-                UUID.fromString("03300357-b02d-477c-b3cf-630010de83e1"),
-                UUID.fromString("e169af81-3b6d-4321-985f-649d48233a12"),
-                UUID.fromString("ff4d74b3-6675-4131-83a0-275e53273533"),
-                UUID.fromString("5f18c0ec-3b51-41f7-b9e0-c6e59b8368f4"),
-            )
-            val used = friends.filter { uuid -> uuid.toString().last().let { it == '0' || it == '2' || it == '3' } }
-            coEvery { supplier.getFriends(id) } returns friends.asFlow()
-            coEvery { cache.addFriend(id, any()) } returns true
-
-            assertEquals(used, entitySupplier.getFriends(id).filter { uuid -> uuid.toString().last().let { it == '0' || it == '2' || it == '3' } }.toList())
-            coVerify(exactly = 1) { supplier.getFriends(id) }
-
-            friends.forEach {
-                coVerify(exactly = 1) { cache.addFriend(id, it) }
-            }
+            coVerify(exactly = 1) { cache.setFriends(id, friends.toSet()) }
         }
     }
 


### PR DESCRIPTION
This reverts commit d8e3bd63986503c82f667618493e8a510b0e768a.

For the moment, we need to choice if all friends should be retrieved and set in cache or only the friends collected from the database.
Moreover, the flow format take a long time to be processed due to the following steps :
- Open flow database
- Delete key in cache
- Each id in flow is added as Friend in cache
Instead of set all friends once times