### PR TITLE
fix: Single responsibility for add friend database

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/core/data/Friends.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Friends.kt
@@ -229,7 +229,6 @@ public class FriendCacheService(
 public class FriendDatabaseService(public val database: R2dbcDatabase) : IFriendDatabaseService {
 
     override suspend fun addFriend(uuid: UUID, friend: UUID): Boolean {
-        if (isFriend(uuid, friend)) return false
         val query = QueryDsl.insert(friends).single(Friends(uuid, friend))
         database.runQuery(query)
         return true

--- a/src/test/kotlin/com/github/rushyverse/core/data/friend/FriendDatabaseServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/friend/FriendDatabaseServiceTest.kt
@@ -81,12 +81,15 @@ class FriendDatabaseServiceTest {
         }
 
         @Test
-        fun `should not add friend if relation already exists`() = runTest {
+        fun `should add friend if relation already exists`() = runTest {
             val uuid1 = UUID.randomUUID()
             val uuid2 = UUID.randomUUID()
 
             assertTrue { service.addFriend(uuid1, uuid2) }
-            assertFalse { service.addFriend(uuid1, uuid2) }
+            assertTrue { service.addFriend(uuid1, uuid2) }
+
+            val result = getAllFriends()
+            assertThat(result).containsExactlyInAnyOrder(Friends(uuid1, uuid2, 1), Friends(uuid1, uuid2, 2))
         }
 
         @Test
@@ -95,7 +98,10 @@ class FriendDatabaseServiceTest {
             val uuid2 = UUID.randomUUID()
 
             assertTrue { service.addFriend(uuid1, uuid2) }
-            assertFalse { service.addFriend(uuid2, uuid1) }
+            assertTrue { service.addFriend(uuid2, uuid1) }
+
+            val result = getAllFriends()
+            assertThat(result).containsExactlyInAnyOrder(Friends(uuid1, uuid2, 1), Friends(uuid2, uuid1, 2))
         }
 
     }


### PR DESCRIPTION
# Context

Currently, the addFriend method check if the relation already exists but it's not the responsability of this method