### PR TITLE
tests(mojang_service): Add IT tests for Mojang service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    val ktorVersion = "2.2.2"
+    val ktorVersion = "2.2.3"
     val ktSerializationVersion = "1.4.1"
     val coroutinesCoreVersion = "1.6.4"
     val loggingVersion = "3.0.4"
@@ -23,7 +23,7 @@ dependencies {
     val junitVersion = "5.9.2"
     val testContainersVersion = "1.17.6"
     val lettuceVersion = "6.2.2.RELEASE"
-    val kotlinMojangApi = "2.1.0"
+    val kotlinMojangApi = "2.2.0"
     val nettyCodecVersion = "4.1.87.Final"
     val assertJcoreVersion = "3.24.2"
     val komapperVersion = "1.6.1"

--- a/src/test/kotlin/com/github/rushyverse/core/data/mojang/MojangServiceIT.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/mojang/MojangServiceIT.kt
@@ -1,0 +1,120 @@
+package com.github.rushyverse.core.data.mojang
+
+import com.github.rushyverse.core.cache.CacheClient
+import com.github.rushyverse.core.container.createRedisContainer
+import com.github.rushyverse.core.data.MojangService
+import com.github.rushyverse.core.supplier.http.HttpSupplierServices
+import com.github.rushyverse.core.supplier.http.IHttpEntitySupplier
+import io.github.universeproject.kotlinmojangapi.MojangAPIImpl
+import io.ktor.client.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.serialization.kotlinx.json.*
+import io.lettuce.core.RedisURI
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Timeout
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@Timeout(10, unit = TimeUnit.SECONDS)
+@Testcontainers
+class MojangServiceIT {
+
+    companion object {
+        @JvmStatic
+        @Container
+        private val redisContainer = createRedisContainer()
+    }
+
+    lateinit var cache: CacheClient
+    lateinit var httpClient: HttpClient
+    lateinit var services: HttpSupplierServices
+
+    @BeforeTest
+    fun onBefore(): Unit = runBlocking {
+        cache = CacheClient {
+            uri = RedisURI.create(redisContainer.url)
+        }
+        httpClient = HttpClient {
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+        val mojangAPI = MojangAPIImpl(httpClient)
+        services = HttpSupplierServices(mojangAPI, cache)
+    }
+
+    @AfterTest
+    fun onAfter(): Unit = runBlocking {
+        cache.connect {
+            it.flushall()
+        }
+
+        httpClient.close()
+        cache.closeAsync().await()
+    }
+
+    @Nested
+    inner class GetSkinById {
+
+        @Test
+        fun `should store and retrieve from cache`() = runTest {
+            val id = "069a79f4-44e9-4726-a5be-fca90e38aaf5"
+            val supplier = IHttpEntitySupplier.cacheWithCachingRestFallback(services)
+            val serviceWeb = MojangService(supplier)
+            val skinFromWeb = serviceWeb.getSkinById(id)
+
+            val serviceCache = serviceWeb.withStrategy(IHttpEntitySupplier.cache(services))
+            val skinFromCache = serviceCache.getSkinById(id)
+
+            assertEquals(skinFromWeb, skinFromCache)
+        }
+
+    }
+
+
+    @Nested
+    inner class GetSkinByName {
+
+        @Test
+        fun `should store and retrieve from cache`() = runTest {
+            val id = "Notch"
+            val supplier = IHttpEntitySupplier.cacheWithCachingRestFallback(services)
+            val serviceWeb = MojangService(supplier)
+            val skinFromWeb = serviceWeb.getSkinByName(id)
+
+            val serviceCache = serviceWeb.withStrategy(IHttpEntitySupplier.cache(services))
+            val skinFromCache = serviceCache.getSkinById(id)
+
+            assertEquals(skinFromWeb, skinFromCache)
+        }
+
+    }
+
+    @Nested
+    inner class GetIdByName {
+
+        @Test
+        fun `should store and retrieve from cache`() = runTest {
+            val id = "Notch"
+            val supplier = IHttpEntitySupplier.cacheWithCachingRestFallback(services)
+            val serviceWeb = MojangService(supplier)
+            val skinFromWeb = serviceWeb.getIdByName(id)
+
+            val serviceCache = serviceWeb.withStrategy(IHttpEntitySupplier.cache(services))
+            val skinFromCache = serviceCache.getIdByName(id)
+
+            assertEquals(skinFromWeb, skinFromCache)
+        }
+
+    }
+}

--- a/src/test/kotlin/com/github/rushyverse/core/data/mojang/MojangServiceIT.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/mojang/MojangServiceIT.kt
@@ -34,9 +34,9 @@ class MojangServiceIT {
         private val redisContainer = createRedisContainer()
     }
 
-    lateinit var cache: CacheClient
-    lateinit var httpClient: HttpClient
-    lateinit var services: HttpSupplierServices
+    private lateinit var cache: CacheClient
+    private lateinit var httpClient: HttpClient
+    private lateinit var services: HttpSupplierServices
 
     @BeforeTest
     fun onBefore(): Unit = runBlocking {

--- a/src/test/kotlin/com/github/rushyverse/core/data/mojang/MojangServiceIT.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/mojang/MojangServiceIT.kt
@@ -87,13 +87,13 @@ class MojangServiceIT {
 
         @Test
         fun `should store and retrieve from cache`() = runTest {
-            val id = "Notch"
+            val name = "Notch"
             val supplier = IHttpEntitySupplier.cacheWithCachingRestFallback(services)
             val serviceWeb = MojangService(supplier)
-            val skinFromWeb = serviceWeb.getSkinByName(id)
+            val skinFromWeb = serviceWeb.getSkinByName(name)
 
             val serviceCache = serviceWeb.withStrategy(IHttpEntitySupplier.cache(services))
-            val skinFromCache = serviceCache.getSkinById(id)
+            val skinFromCache = serviceCache.getSkinByName(name)
 
             assertEquals(skinFromWeb, skinFromCache)
         }
@@ -105,13 +105,13 @@ class MojangServiceIT {
 
         @Test
         fun `should store and retrieve from cache`() = runTest {
-            val id = "Notch"
+            val name = "Notch"
             val supplier = IHttpEntitySupplier.cacheWithCachingRestFallback(services)
             val serviceWeb = MojangService(supplier)
-            val skinFromWeb = serviceWeb.getIdByName(id)
+            val skinFromWeb = serviceWeb.getIdByName(name)
 
             val serviceCache = serviceWeb.withStrategy(IHttpEntitySupplier.cache(services))
-            val skinFromCache = serviceCache.getIdByName(id)
+            val skinFromCache = serviceCache.getIdByName(name)
 
             assertEquals(skinFromWeb, skinFromCache)
         }


### PR DESCRIPTION
# Context

@Quentixx discovered a weird behavior when we get a skin from Mojang API and send it into the cache.
The Mojang API give a UUID without dashes, however, when in a server, we're trying to get the skin from cache by the UUID of a player, it contains dashes.

So the cache contains a key like : `skin:069a79f444e94726a5befca90e38aaf5` but we try to get a skin with the key `skin:069a79f4-44e9-4726-a5be-fca90e38aaf5`.

A fix was made in the [mojang-api library](https://github.com/UniverseProject/kotlin-mojang-api/releases/tag/v2.2.0) and now, we need to wait the new version in maven central