### PR TITLE
chore: Simplify withStrategy method

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/core/data/Mojang.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Mojang.kt
@@ -1,5 +1,6 @@
 package com.github.rushyverse.core.data
 
+import com.github.rushyverse.core.supplier.http.HttpSupplierConfiguration
 import com.github.rushyverse.core.supplier.http.IHttpEntitySupplier
 import com.github.rushyverse.core.supplier.http.IHttpStrategizable
 import io.github.universeproject.kotlinmojangapi.ProfileId
@@ -36,7 +37,8 @@ public class MojangService(override val supplier: IHttpEntitySupplier) : IMojang
         return supplier.getIdByName(name)
     }
 
-    override fun withStrategy(strategy: IHttpEntitySupplier): MojangService {
-        return MojangService(strategy)
+    override fun withStrategy(getStrategy: (HttpSupplierConfiguration) -> IHttpEntitySupplier): MojangService {
+        val newSupplier = getStrategy(supplier.configuration)
+        return MojangService(newSupplier)
     }
 }

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseCacheEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseCacheEntitySupplier.kt
@@ -4,8 +4,7 @@ import com.github.rushyverse.core.data.IFriendCacheService
 
 /**
  * [IDatabaseEntitySupplier] that uses cache to manage entities.
- * @property friendCacheService Friend cache service.
  */
-public class DatabaseCacheEntitySupplier(public val friendCacheService: IFriendCacheService) :
+public class DatabaseCacheEntitySupplier(public override val configuration: DatabaseSupplierConfiguration) :
     IDatabaseEntitySupplier,
-    IFriendCacheService by friendCacheService
+    IFriendCacheService by configuration.friendServices.first

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseEntitySupplier.kt
@@ -4,8 +4,7 @@ import com.github.rushyverse.core.data.IFriendDatabaseService
 
 /**
  * [IDatabaseEntitySupplier] that uses database to manage entities.
- * @property service Friend database service.
  */
-public class DatabaseEntitySupplier(public val service: IFriendDatabaseService) :
+public class DatabaseEntitySupplier(public override val configuration: DatabaseSupplierConfiguration) :
     IDatabaseEntitySupplier,
-    IFriendDatabaseService by service
+    IFriendDatabaseService by configuration.friendServices.second

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseFallbackEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseFallbackEntitySupplier.kt
@@ -10,6 +10,8 @@ import java.util.*
  * Each supplier is used according to a priority.
  * [getPriority] is used first when a data is retrieved. If the data is not found, [setPriority] is used.
  * [setPriority] is used first when a data is set. If the data is set, the same information is set using [getPriority].
+ * To keep consistency, it is recommended to use the same [DatabaseSupplierConfiguration] for both suppliers.
+ * The value of [configuration] depends on one of the suppliers.
  * @property getPriority Priority of the supplier used when a data is retrieved.
  * @property setPriority Priority of the supplier used when a data is set.
  */
@@ -17,6 +19,9 @@ public class DatabaseFallbackEntitySupplier(
     public val getPriority: IDatabaseEntitySupplier,
     public val setPriority: IDatabaseEntitySupplier
 ) : IDatabaseEntitySupplier {
+
+    override val configuration: DatabaseSupplierConfiguration
+        get() = getPriority.configuration
 
     override suspend fun addFriend(uuid: UUID, friend: UUID): Boolean {
         return setPriority.addFriend(uuid, friend)

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplier.kt
@@ -7,13 +7,19 @@ import java.util.*
 
 /**
  * [IDatabaseEntitySupplier] that delegates to another [IDatabaseEntitySupplier] to resolve entities.
- *
- * Resolved entities will always be stored in [cache] if it wasn't null or empty for flows.
+ * Resolved entities will always be stored in [cache] if it wasn't null.
+ * To keep consistency, it is recommended to use the same [DatabaseSupplierConfiguration] for both suppliers.
+ * The value of [configuration] depends on one of the suppliers.
+ * @property cache Supplier used to interact with the cache.
+ * @property supplier Supplier used to interact with a custom way.
  */
 public class DatabaseStoreEntitySupplier(
     public val cache: DatabaseCacheEntitySupplier,
     public val supplier: IDatabaseEntitySupplier
 ) : IDatabaseEntitySupplier {
+
+    override val configuration: DatabaseSupplierConfiguration
+        get() = cache.configuration
 
     override suspend fun addFriend(uuid: UUID, friend: UUID): Boolean {
         return if (supplier.addFriend(uuid, friend)) {

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseSupplierConfiguration.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseSupplierConfiguration.kt
@@ -7,6 +7,6 @@ import com.github.rushyverse.core.data.IFriendDatabaseService
  * Contains all necessary services to manage entities linked to the database and cache.
  * @property friendServices Friends services.
  */
-public data class DatabaseSupplierServices(
+public data class DatabaseSupplierConfiguration(
     val friendServices: Pair<IFriendCacheService, IFriendDatabaseService>,
 )

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/IDatabaseEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/IDatabaseEntitySupplier.kt
@@ -15,15 +15,16 @@ public interface IDatabaseStrategizable {
      */
     public val supplier: IDatabaseEntitySupplier
 
-
     /**
-     * Returns a copy of this class with a new [supplier] provided by the [strategy].
+     * Returns a copy of this class with a new [supplier] provided by the [getStrategy].
+     * @param getStrategy A function that will provide a new [IDatabaseEntitySupplier] based on the [DatabaseSupplierConfiguration] configuration.
      */
-    public fun withStrategy(strategy: IDatabaseEntitySupplier): IDatabaseStrategizable
+    public fun withStrategy(getStrategy: (DatabaseSupplierConfiguration) -> IDatabaseEntitySupplier): IDatabaseStrategizable
 }
 
 /**
  * An abstraction that allows for requesting entities.
+ * @property configuration The configuration used to create this supplier.
  *
  * @see DatabaseEntitySupplier
  * @see DatabaseCacheEntitySupplier
@@ -38,22 +39,22 @@ public interface IDatabaseEntitySupplier : IFriendService {
          * A supplier providing a strategy which exclusively uses database calls to fetch entities.
          * See [DatabaseEntitySupplier] for more details.
          */
-        public fun database(configuration: DatabaseSupplierServices): DatabaseEntitySupplier =
-            DatabaseEntitySupplier(configuration.friendServices.second)
+        public fun database(configuration: DatabaseSupplierConfiguration): DatabaseEntitySupplier =
+            DatabaseEntitySupplier(configuration)
 
         /**
          * A supplier providing a strategy which exclusively uses cache to fetch entities.
          * See [DatabaseCacheEntitySupplier] for more details.
          */
-        public fun cache(configuration: DatabaseSupplierServices): DatabaseCacheEntitySupplier =
-            DatabaseCacheEntitySupplier(configuration.friendServices.first)
+        public fun cache(configuration: DatabaseSupplierConfiguration): DatabaseCacheEntitySupplier =
+            DatabaseCacheEntitySupplier(configuration)
 
         /**
          * A supplier providing a strategy which exclusively uses database calls to fetch entities.
          * fetched entities are stored in [cache].
          * See [DatabaseStoreEntitySupplier] for more details.
          */
-        public fun cachingDatabase(configuration: DatabaseSupplierServices): DatabaseStoreEntitySupplier =
+        public fun cachingDatabase(configuration: DatabaseSupplierConfiguration): DatabaseStoreEntitySupplier =
             DatabaseStoreEntitySupplier(cache(configuration), database(configuration))
 
         /**
@@ -61,7 +62,7 @@ public interface IDatabaseEntitySupplier : IFriendService {
          * is not present from cache it will be fetched from [database] instead. Operations that return flows
          * will only fall back to rest when the returned flow contained no elements.
          */
-        public fun cacheWithDatabaseFallback(configuration: DatabaseSupplierServices): DatabaseFallbackEntitySupplier =
+        public fun cacheWithDatabaseFallback(configuration: DatabaseSupplierConfiguration): DatabaseFallbackEntitySupplier =
             DatabaseFallbackEntitySupplier(getPriority = cache(configuration), setPriority = database(configuration))
 
         /**
@@ -69,11 +70,13 @@ public interface IDatabaseEntitySupplier : IFriendService {
          * is not present from cache it will be fetched from [cachingDatabase] instead which will update [cache] with fetched elements.
          * Operations that return flows will only fall back to rest when the returned flow contained no elements.
          */
-        public fun cacheWithCachingDatabaseFallback(configuration: DatabaseSupplierServices): DatabaseFallbackEntitySupplier =
+        public fun cacheWithCachingDatabaseFallback(configuration: DatabaseSupplierConfiguration): DatabaseFallbackEntitySupplier =
             DatabaseFallbackEntitySupplier(
                 getPriority = cache(configuration),
                 setPriority = cachingDatabase(configuration)
             )
 
     }
+
+    public val configuration: DatabaseSupplierConfiguration
 }

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/http/HttpCacheEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/http/HttpCacheEntitySupplier.kt
@@ -3,30 +3,12 @@ package com.github.rushyverse.core.supplier.http
 import com.github.rushyverse.core.cache.AbstractCacheService
 import com.github.rushyverse.core.data.IProfileIdCacheService
 import com.github.rushyverse.core.data.IProfileSkinCacheService
-import io.github.universeproject.kotlinmojangapi.ProfileId
-import io.github.universeproject.kotlinmojangapi.ProfileSkin
 
 /**
  * [IHttpEntitySupplier] that uses [AbstractCacheService] to resolve entities.
  */
 public class HttpCacheEntitySupplier(
-    public val profileSkinCache: IProfileSkinCacheService,
-    public val profileIdCache: IProfileIdCacheService
-) : IHttpEntitySupplier {
-
-    override suspend fun getSkinById(id: String): ProfileSkin? {
-        return profileSkinCache.getSkinById(id)
-    }
-
-    override suspend fun getIdByName(name: String): ProfileId? {
-        return profileIdCache.getIdByName(name)
-    }
-
-    public suspend fun save(profile: ProfileId) {
-        profileIdCache.save(profile)
-    }
-
-    public suspend fun save(profile: ProfileSkin) {
-        profileSkinCache.save(profile)
-    }
-}
+    override val configuration: HttpSupplierConfiguration,
+) : IHttpEntitySupplier,
+    IProfileSkinCacheService by configuration.profileSkinCache,
+    IProfileIdCacheService by configuration.profileIdCache

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/http/HttpEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/http/HttpEntitySupplier.kt
@@ -1,6 +1,5 @@
 package com.github.rushyverse.core.supplier.http
 
-import io.github.universeproject.kotlinmojangapi.MojangAPI
 import io.github.universeproject.kotlinmojangapi.ProfileId
 import io.github.universeproject.kotlinmojangapi.ProfileSkin
 import io.ktor.client.*
@@ -8,7 +7,9 @@ import io.ktor.client.*
 /**
  * [IHttpEntitySupplier] that uses a [HttpClient] to resolve entities.
  */
-public class HttpEntitySupplier(public val mojangAPI: MojangAPI) : IHttpEntitySupplier {
+public class HttpEntitySupplier(override val configuration: HttpSupplierConfiguration) : IHttpEntitySupplier {
+
+    private val mojangAPI = configuration.mojangAPI
 
     override suspend fun getIdByName(name: String): ProfileId? {
         return mojangAPI.getUUID(name)

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/http/HttpFallbackEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/http/HttpFallbackEntitySupplier.kt
@@ -5,11 +5,18 @@ import io.github.universeproject.kotlinmojangapi.ProfileSkin
 
 /**
  * [IHttpEntitySupplier] that uses the first supplier to retrieve a data, if the value is null, get the data through the second supplier.
+ * To keep consistency, it is recommended to use the same [HttpSupplierConfiguration] for both suppliers.
+ * The value of [configuration] depends on one of the suppliers.
+ * @property first Used first to interact with a data.
+ * @property second Used second to interact with a data.
  */
 public class HttpFallbackEntitySupplier(
     public val first: IHttpEntitySupplier,
     public val second: IHttpEntitySupplier
 ) : IHttpEntitySupplier {
+
+    override val configuration: HttpSupplierConfiguration
+        get() = first.configuration
 
     override suspend fun getSkinById(id: String): ProfileSkin? {
         return invoke { it.getSkinById(id) }

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/http/HttpStoreEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/http/HttpStoreEntitySupplier.kt
@@ -5,13 +5,19 @@ import io.github.universeproject.kotlinmojangapi.ProfileSkin
 
 /**
  * [IHttpEntitySupplier] that delegates to another [IHttpEntitySupplier] to resolve entities.
- *
- * Resolved entities will always be stored in [cache] if it wasn't null or empty for flows.
+ * Resolved entities will always be stored in [cache] if it wasn't null.
+ * To keep consistency, it is recommended to use the same [HttpSupplierConfiguration] for both suppliers.
+ * The value of [configuration] depends on one of the suppliers.
+ * @property cache Supplier used to interact with the cache.
+ * @property supplier Supplier used to interact with a custom way.
  */
 public class HttpStoreEntitySupplier(
     public val cache: HttpCacheEntitySupplier,
     public val supplier: IHttpEntitySupplier
 ) : IHttpEntitySupplier {
+
+    override val configuration: HttpSupplierConfiguration
+        get() = cache.configuration
 
     override suspend fun getIdByName(name: String): ProfileId? {
         return supplier.getIdByName(name)?.also { cache.save(it) }

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/http/HttpSupplierConfiguration.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/http/HttpSupplierConfiguration.kt
@@ -7,11 +7,23 @@ import com.github.rushyverse.core.data.ProfileIdCacheService
 import com.github.rushyverse.core.data.ProfileSkinCacheService
 import io.github.universeproject.kotlinmojangapi.MojangAPI
 
-public class HttpSupplierServices(
+/**
+ * Contains the configuration for a HTTP supplier.
+ * @property mojangAPI Allows to request data from the Mojang API.
+ * @property profileSkinCache Skin cache service.
+ * @property profileIdCache Profile ID cache service.
+ */
+public class HttpSupplierConfiguration(
     public val mojangAPI: MojangAPI,
     public val profileSkinCache: IProfileSkinCacheService,
     public val profileIdCache: IProfileIdCacheService,
 ) {
+
+    /**
+     * Creates a new instance of [HttpSupplierConfiguration].
+     * @param mojangAPI Allows to request data from the Mojang API.
+     * @param cacheClient Cache client used to create the cache services [profileSkinCache] and [profileIdCache].
+     */
     public constructor(mojangAPI: MojangAPI, cacheClient: CacheClient) : this(
         mojangAPI,
         ProfileSkinCacheService(cacheClient),

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/http/IHttpEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/http/IHttpEntitySupplier.kt
@@ -16,15 +16,16 @@ public interface IHttpStrategizable {
      */
     public val supplier: IHttpEntitySupplier
 
-
     /**
-     * Returns a copy of this class with a new [supplier] provided by the [strategy].
+     * Returns a copy of this class with a new [supplier] provided by the [getStrategy].
+     * @param getStrategy A function that will provide a new [IHttpEntitySupplier] based on the [HttpSupplierConfiguration] configuration.
      */
-    public fun withStrategy(strategy: IHttpEntitySupplier): IHttpStrategizable
+    public fun withStrategy(getStrategy: (HttpSupplierConfiguration) -> IHttpEntitySupplier): IHttpStrategizable
 }
 
 /**
  * An abstraction that allows for requesting entities.
+ * @property configuration The configuration used to create this supplier.
  *
  * @see HttpEntitySupplier
  * @see HttpCacheEntitySupplier
@@ -38,22 +39,22 @@ public interface IHttpEntitySupplier : IProfileSkinService, IProfileIdService {
          * A supplier providing a strategy which exclusively uses database calls to fetch entities.
          * See [HttpEntitySupplier] for more details.
          */
-        public fun rest(configuration: HttpSupplierServices): IHttpEntitySupplier =
-            HttpEntitySupplier(configuration.mojangAPI)
+        public fun rest(configuration: HttpSupplierConfiguration): IHttpEntitySupplier =
+            HttpEntitySupplier(configuration)
 
         /**
          * A supplier providing a strategy which exclusively uses cache to fetch entities.
          * See [HttpCacheEntitySupplier] for more details.
          */
-        public fun cache(configuration: HttpSupplierServices): HttpCacheEntitySupplier =
-            HttpCacheEntitySupplier(configuration.profileSkinCache, configuration.profileIdCache)
+        public fun cache(configuration: HttpSupplierConfiguration): HttpCacheEntitySupplier =
+            HttpCacheEntitySupplier(configuration)
 
         /**
          * A supplier providing a strategy which exclusively uses database calls to fetch entities.
          * fetched entities are stored in [cache].
          * See [HttpStoreEntitySupplier] for more details.
          */
-        public fun cachingRest(configuration: HttpSupplierServices): HttpStoreEntitySupplier =
+        public fun cachingRest(configuration: HttpSupplierConfiguration): HttpStoreEntitySupplier =
             HttpStoreEntitySupplier(cache(configuration), rest(configuration))
 
         /**
@@ -61,7 +62,7 @@ public interface IHttpEntitySupplier : IProfileSkinService, IProfileIdService {
          * is not present from cache it will be fetched from [rest] instead. Operations that return flows
          * will only fall back to rest when the returned flow contained no elements.
          */
-        public fun cacheWithRestFallback(configuration: HttpSupplierServices): IHttpEntitySupplier =
+        public fun cacheWithRestFallback(configuration: HttpSupplierConfiguration): IHttpEntitySupplier =
             HttpFallbackEntitySupplier(cache(configuration), rest(configuration))
 
         /**
@@ -69,8 +70,10 @@ public interface IHttpEntitySupplier : IProfileSkinService, IProfileIdService {
          * is not present from cache it will be fetched from [cachingRest] instead which will update [cache] with fetched elements.
          * Operations that return flows will only fall back to rest when the returned flow contained no elements.
          */
-        public fun cacheWithCachingRestFallback(configuration: HttpSupplierServices): IHttpEntitySupplier =
+        public fun cacheWithCachingRestFallback(configuration: HttpSupplierConfiguration): IHttpEntitySupplier =
             HttpFallbackEntitySupplier(cache(configuration), cachingRest(configuration))
     }
+
+    public val configuration: HttpSupplierConfiguration
 
 }

--- a/src/test/kotlin/com/github/rushyverse/core/data/friend/FriendCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/friend/FriendCacheServiceTest.kt
@@ -7,7 +7,7 @@ import com.github.rushyverse.core.data.FriendCacheService
 import com.github.rushyverse.core.data.IFriendCacheService
 import com.github.rushyverse.core.data.IFriendDatabaseService
 import com.github.rushyverse.core.serializer.UUIDSerializer
-import com.github.rushyverse.core.supplier.database.DatabaseSupplierServices
+import com.github.rushyverse.core.supplier.database.DatabaseSupplierConfiguration
 import io.lettuce.core.RedisURI
 import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
 import io.mockk.coEvery
@@ -67,7 +67,7 @@ class FriendCacheServiceTest {
     @Nested
     inner class UserCacheToDatabase {
 
-        private lateinit var configuration: DatabaseSupplierServices
+        private lateinit var configuration: DatabaseSupplierConfiguration
         private lateinit var cacheServiceMock: IFriendCacheService
         private lateinit var databaseService: IFriendDatabaseService
 
@@ -76,7 +76,7 @@ class FriendCacheServiceTest {
             cacheServiceMock = mockk()
             databaseService = mockk()
 
-            configuration = DatabaseSupplierServices(
+            configuration = DatabaseSupplierConfiguration(
                 cacheServiceMock to databaseService
             )
         }

--- a/src/test/kotlin/com/github/rushyverse/core/data/friend/FriendServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/friend/FriendServiceTest.kt
@@ -1,12 +1,10 @@
 package com.github.rushyverse.core.data.friend
 
 import com.github.rushyverse.core.data.FriendService
+import com.github.rushyverse.core.supplier.database.DatabaseSupplierConfiguration
 import com.github.rushyverse.core.supplier.database.IDatabaseEntitySupplier
 import com.github.rushyverse.core.utils.getRandomString
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.mockk
-import io.mockk.slot
+import io.mockk.*
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.toList
@@ -27,12 +25,18 @@ class FriendServiceTest {
 
     @Test
     fun `should create a new instance with another strategy`() {
+        val configuration = mockk<DatabaseSupplierConfiguration>(getRandomString())
         val strategy = mockk<IDatabaseEntitySupplier>(getRandomString())
+        every { strategy.configuration } returns configuration
+
         val service = FriendService(strategy)
         assertEquals(strategy, service.supplier)
 
         val strategy2 = mockk<IDatabaseEntitySupplier>(getRandomString())
-        val service2 = service.withStrategy(strategy2)
+        val service2 = service.withStrategy {
+            assertEquals(configuration, it)
+            strategy2
+        }
         assertEquals(strategy2, service2.supplier)
 
     }

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseCacheEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseCacheEntitySupplierTest.kt
@@ -23,7 +23,8 @@ class DatabaseCacheEntitySupplierTest {
     @BeforeTest
     fun onBefore() = runBlocking {
         cacheService = mockk()
-        cacheEntitySupplier = DatabaseCacheEntitySupplier(cacheService)
+        val configuration = DatabaseSupplierConfiguration(cacheService to mockk())
+        cacheEntitySupplier = DatabaseCacheEntitySupplier(configuration)
     }
 
     @Nested

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseEntitySupplierTest.kt
@@ -1,6 +1,7 @@
 package com.github.rushyverse.core.supplier.database
 
 import com.github.rushyverse.core.data.FriendDatabaseService
+import com.github.rushyverse.core.data.IFriendCacheService
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -21,7 +22,8 @@ class DatabaseEntitySupplierTest {
     @BeforeTest
     fun onBefore() {
         service = mockk()
-        databaseEntitySupplier = DatabaseEntitySupplier(service)
+        val configuration = DatabaseSupplierConfiguration(mockk<IFriendCacheService>() to service)
+        databaseEntitySupplier = DatabaseEntitySupplier(configuration)
     }
 
     @Nested

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseFallbackEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseFallbackEntitySupplierTest.kt
@@ -1,9 +1,7 @@
 package com.github.rushyverse.core.supplier.database
 
 import com.github.rushyverse.core.utils.getRandomString
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.toList
@@ -23,6 +21,15 @@ class DatabaseFallbackEntitySupplierTest {
         getPrioritySupplier = mockk(getRandomString())
         setPrioritySupplier = mockk(getRandomString())
         fallbackEntitySupplier = DatabaseFallbackEntitySupplier(getPrioritySupplier, setPrioritySupplier)
+    }
+
+    @Test
+    fun `get configuration will get from getPriority supplier`() = runTest {
+        val configuration = mockk<DatabaseSupplierConfiguration>(getRandomString())
+        every { getPrioritySupplier.configuration } returns configuration
+
+        assertEquals(configuration, fallbackEntitySupplier.configuration)
+        verify(exactly = 1) { getPrioritySupplier.configuration }
     }
 
     @Nested

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplierTest.kt
@@ -1,9 +1,7 @@
 package com.github.rushyverse.core.supplier.database
 
 import com.github.rushyverse.core.utils.getRandomString
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.toList
@@ -23,6 +21,15 @@ class DatabaseStoreEntitySupplierTest {
         cache = mockk(getRandomString())
         supplier = mockk(getRandomString())
         entitySupplier = DatabaseStoreEntitySupplier(cache, supplier)
+    }
+
+    @Test
+    fun `get configuration will get from cache supplier`() = runTest {
+        val configuration = mockk<DatabaseSupplierConfiguration>(getRandomString())
+        every { cache.configuration } returns configuration
+
+        assertEquals(configuration, entitySupplier.configuration)
+        verify(exactly = 1) { cache.configuration }
     }
 
     @Nested

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/IDatabaseEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/IDatabaseEntitySupplierTest.kt
@@ -11,26 +11,24 @@ class IDatabaseEntitySupplierTest {
     @Test
     fun `database supplier corresponding to the class`() {
         val service = mockk<IFriendDatabaseService>()
-        val configuration = DatabaseSupplierServices(mockk<IFriendCacheService>() to service)
+        val configuration = DatabaseSupplierConfiguration(mockk<IFriendCacheService>() to service)
         val supplier = IDatabaseEntitySupplier.database(configuration)
         assertEquals(DatabaseEntitySupplier::class, supplier::class)
-        assertEquals(service, supplier.service)
     }
 
     @Test
     fun `cache supplier corresponding to the class`() {
         val service = mockk<IFriendCacheService>()
-        val configuration = DatabaseSupplierServices(service to mockk())
+        val configuration = DatabaseSupplierConfiguration(service to mockk())
         val supplier = IDatabaseEntitySupplier.cache(configuration)
         assertEquals(DatabaseCacheEntitySupplier::class, supplier::class)
-        assertEquals(service, supplier.friendCacheService)
     }
 
     @Test
     fun `cachingDatabase supplier corresponding to the class`() {
         val cacheService = mockk<IFriendCacheService>()
         val databaseService = mockk<IFriendDatabaseService>()
-        val configuration = DatabaseSupplierServices(cacheService to databaseService)
+        val configuration = DatabaseSupplierConfiguration(cacheService to databaseService)
         val supplier = IDatabaseEntitySupplier.cachingDatabase(configuration)
         assertEquals(DatabaseStoreEntitySupplier::class, supplier::class)
         assertEquals(DatabaseCacheEntitySupplier::class, supplier.cache::class)
@@ -41,7 +39,7 @@ class IDatabaseEntitySupplierTest {
     fun `cacheWithDatabaseFallback supplier corresponding to the class`() {
         val cacheService = mockk<IFriendCacheService>()
         val databaseService = mockk<IFriendDatabaseService>()
-        val configuration = DatabaseSupplierServices(cacheService to databaseService)
+        val configuration = DatabaseSupplierConfiguration(cacheService to databaseService)
         val supplier = IDatabaseEntitySupplier.cacheWithDatabaseFallback(configuration)
         assertEquals(DatabaseFallbackEntitySupplier::class, supplier::class)
         assertEquals(DatabaseCacheEntitySupplier::class, supplier.getPriority::class)
@@ -52,7 +50,7 @@ class IDatabaseEntitySupplierTest {
     fun `cacheWithCachingDatabaseFallback supplier corresponding to the class`() {
         val cacheService = mockk<IFriendCacheService>()
         val databaseService = mockk<IFriendDatabaseService>()
-        val configuration = DatabaseSupplierServices(cacheService to databaseService)
+        val configuration = DatabaseSupplierConfiguration(cacheService to databaseService)
         val supplier = IDatabaseEntitySupplier.cacheWithCachingDatabaseFallback(configuration)
         assertEquals(DatabaseFallbackEntitySupplier::class, supplier::class)
         assertEquals(DatabaseCacheEntitySupplier::class, supplier.getPriority::class)

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/http/HttpCacheEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/http/HttpCacheEntitySupplierTest.kt
@@ -41,7 +41,8 @@ class HttpCacheEntitySupplierTest {
         @Test
         fun `get id use the mock method`() = runTest {
             val cacheService = mockk<ProfileIdCacheService>()
-            val supplier = HttpCacheEntitySupplier(mockk(), cacheService)
+            val configuration = HttpSupplierConfiguration(mockk(), mockk(), cacheService)
+            val supplier = HttpCacheEntitySupplier(configuration)
 
             val profile = createProfileId()
             val name = profile.name
@@ -54,7 +55,8 @@ class HttpCacheEntitySupplierTest {
         @Test
         fun `save id use the mock method`() = runTest {
             val cacheService = mockk<ProfileIdCacheService>()
-            val supplier = HttpCacheEntitySupplier(mockk(), cacheService)
+            val configuration = HttpSupplierConfiguration(mockk(), mockk(), cacheService)
+            val supplier = HttpCacheEntitySupplier(configuration)
 
             val profile = createProfileId()
             coJustRun { cacheService.save(profile) }
@@ -81,27 +83,29 @@ class HttpCacheEntitySupplierTest {
 
         @Test
         fun `get skin use the mock method`() = runTest {
-            val cacheService = mockk<ProfileSkinCacheService>()
-            val supplier = HttpCacheEntitySupplier(cacheService, mockk())
+            val profileSkinCacheService = mockk<ProfileSkinCacheService>()
+            val configuration = HttpSupplierConfiguration(mockk(), profileSkinCacheService, mockk())
+            val supplier = HttpCacheEntitySupplier(configuration)
 
             val profile = createProfileSkin()
             val uuid = profile.id
-            coEvery { cacheService.getSkinById(uuid) } returns profile
+            coEvery { profileSkinCacheService.getSkinById(uuid) } returns profile
 
             assertEquals(profile, supplier.getSkinById(uuid))
-            coVerify(exactly = 1) { cacheService.getSkinById(uuid) }
+            coVerify(exactly = 1) { profileSkinCacheService.getSkinById(uuid) }
         }
 
         @Test
         fun `save id use the mock method`() = runTest {
-            val cacheService = mockk<ProfileSkinCacheService>()
-            val supplier = HttpCacheEntitySupplier(cacheService, mockk())
+            val profileSkinCacheService = mockk<ProfileSkinCacheService>()
+            val configuration = HttpSupplierConfiguration(mockk(), profileSkinCacheService, mockk())
+            val supplier = HttpCacheEntitySupplier(configuration)
 
             val profile = createProfileSkin()
-            coJustRun { cacheService.save(profile) }
+            coJustRun { profileSkinCacheService.save(profile) }
 
             supplier.save(profile)
-            coVerify(exactly = 1) { cacheService.save(profile) }
+            coVerify(exactly = 1) { profileSkinCacheService.save(profile) }
         }
     }
 }

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/http/HttpEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/http/HttpEntitySupplierTest.kt
@@ -23,7 +23,8 @@ class HttpEntitySupplierTest {
     @BeforeTest
     fun onBefore() {
         mojangAPI = mockk(getRandomString())
-        restEntitySupplier = HttpEntitySupplier(mojangAPI)
+        val configuration = HttpSupplierConfiguration(mojangAPI, mockk(), mockk())
+        restEntitySupplier = HttpEntitySupplier(configuration)
     }
 
     interface RestTest {

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/http/HttpFallbackEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/http/HttpFallbackEntitySupplierTest.kt
@@ -3,9 +3,7 @@ package com.github.rushyverse.core.supplier.http
 import com.github.rushyverse.core.utils.createProfileId
 import com.github.rushyverse.core.utils.createProfileSkin
 import com.github.rushyverse.core.utils.getRandomString
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -21,6 +19,17 @@ class HttpFallbackEntitySupplierTest {
     @BeforeTest
     fun onBefore() {
         fallbackEntitySupplier = HttpFallbackEntitySupplier(mockk(getRandomString()), mockk(getRandomString()))
+    }
+
+    @Test
+    fun `get configuration will get from first supplier`() = runTest {
+        val firstSupplier = fallbackEntitySupplier.first
+
+        val configuration = mockk<HttpSupplierConfiguration>(getRandomString())
+        every { firstSupplier.configuration } returns configuration
+
+        assertEquals(configuration, fallbackEntitySupplier.configuration)
+        verify(exactly = 1) { firstSupplier.configuration }
     }
 
     interface FallbackTest {

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/http/HttpStoreEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/http/HttpStoreEntitySupplierTest.kt
@@ -6,9 +6,12 @@ import com.github.rushyverse.core.data.ProfileIdCacheService
 import com.github.rushyverse.core.data.ProfileSkinCacheService
 import com.github.rushyverse.core.utils.createProfileId
 import com.github.rushyverse.core.utils.createProfileSkin
+import com.github.rushyverse.core.utils.getRandomString
 import io.lettuce.core.RedisURI
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.DisplayName
@@ -47,11 +50,26 @@ class HttpStoreEntitySupplierTest {
         mockSupplier = mockk()
         // Use to verify if data is inserted
         cacheEntitySupplier = HttpCacheEntitySupplier(
-            ProfileSkinCacheService(cacheClient),
-            ProfileIdCacheService(cacheClient)
+            HttpSupplierConfiguration(
+                mockk(),
+                ProfileSkinCacheService(cacheClient),
+                ProfileIdCacheService(cacheClient)
+            )
         )
 
         storeEntitySupplier = HttpStoreEntitySupplier(cacheEntitySupplier, mockSupplier)
+    }
+
+    @Test
+    fun `get configuration will get from cache supplier`() = runTest {
+        val cacheSupplier = mockk<HttpCacheEntitySupplier>(getRandomString())
+        storeEntitySupplier = HttpStoreEntitySupplier(cacheSupplier, mockSupplier)
+
+        val configuration = mockk<HttpSupplierConfiguration>(getRandomString())
+        every { cacheSupplier.configuration } returns configuration
+
+        assertEquals(configuration, storeEntitySupplier.configuration)
+        verify(exactly = 1) { cacheSupplier.configuration }
     }
 
     interface StoreTest {

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/http/IHttpEntitySupplierStrategyTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/http/IHttpEntitySupplierStrategyTest.kt
@@ -34,7 +34,7 @@ class IHttpEntitySupplierStrategyTest {
 
     private lateinit var cacheClient: CacheClient
 
-    private lateinit var configuration: HttpSupplierServices
+    private lateinit var configuration: HttpSupplierConfiguration
 
     private lateinit var mojangAPI: MojangAPI
     private lateinit var cacheEntitySupplier: HttpCacheEntitySupplier
@@ -48,10 +48,14 @@ class IHttpEntitySupplierStrategyTest {
         mojangAPI = mockk(getRandomString())
 
         cacheEntitySupplier = HttpCacheEntitySupplier(
-            ProfileSkinCacheService(cacheClient),
-            ProfileIdCacheService(cacheClient)
+            HttpSupplierConfiguration(
+                mockk(),
+                ProfileSkinCacheService(cacheClient),
+                ProfileIdCacheService(cacheClient)
+            )
         )
-        configuration = HttpSupplierServices(mojangAPI, cacheClient)
+
+        configuration = HttpSupplierConfiguration(mojangAPI, cacheClient)
     }
 
     @AfterTest
@@ -61,13 +65,13 @@ class IHttpEntitySupplierStrategyTest {
 
     @Test
     fun `rest supplier corresponding to the class`() {
-        val configuration = HttpSupplierServices(mockk(), mockk())
+        val configuration = HttpSupplierConfiguration(mockk(), mockk())
         assertEquals(HttpEntitySupplier::class, IHttpEntitySupplier.rest(configuration)::class)
     }
 
     @Test
     fun `cache supplier corresponding to the class`() {
-        val configuration = HttpSupplierServices(mockk(), mockk())
+        val configuration = HttpSupplierConfiguration(mockk(), mockk())
         assertEquals(HttpCacheEntitySupplier::class, IHttpEntitySupplier.cache(configuration)::class)
     }
 


### PR DESCRIPTION
# Context

When you have a Strategizable instance and want to change the supplier used, you need to keep the configuration between other objects to use it to get a new supplier instance.

**Before**
```kt
class A(val strategizable : IHttpStrategizable, val configuration: HttpSupplierConfiguration) {
    init {
      // Need to keep configuration in A instance
       val newStrategizable = strategizable.withStrategy(IHttpEntitySupplier.cache(configuration))
    }
}
```

The goal is to avoid this limit. So the configuration should be stored in the current supplier, to finally be able to retrieve it.

**After**
```kt
class A(val strategizable : IHttpStrategizable) {
    init {
      // Configuration stored in the supplier
       val newStrategizable = strategizable.withStrategy(IHttpEntitySupplier::cache)
    }
}
```

If you need to use a new configuration, `withStrategy` wants a lambda as a parameter, so you will be able to do :

```kt
class A(val strategizable : IHttpStrategizable) {
    init {
      val newConfiguration = HttpSupplierConfiguration(..)
      // Ignore the configuration stored in the supplier
       val newStrategizable = strategizable.withStrategy {
          IHttpEntitySupplier.cache(newConfiguration)
       }
    }
}
```