### PR TITLE
chore: Replace String request to DSL

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/core/data/Friend.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Friend.kt
@@ -666,7 +666,7 @@ public class FriendDatabaseService(public val database: R2dbcDatabase) : IFriend
             }
             .multiple(friends)
 
-        return (database.runQuery(query) > 0)
+        return database.runQuery(query) > 0
     }
 
     /**


### PR DESCRIPTION
# Context

With the new Komapper version, we can change the string request to a DSL request 