### PR TITLE
chore: change invite cache keys

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/core/cache/AbstractCacheService.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/cache/AbstractCacheService.kt
@@ -136,9 +136,9 @@ public abstract class AbstractCacheService(
             var cursor = connection.scan(scanArgs)
             while (cursor != null && currentCoroutineContext().isActive) {
                 val keys = cursor.keys
-                if (keys.isEmpty()) break
-
-                emitAll(builder(connection, keys))
+                if (keys.isNotEmpty()) {
+                    emitAll(builder(connection, keys))
+                }
                 if (cursor.isFinished) break
 
                 cursor = connection.scan(cursor, scanArgs)

--- a/src/main/kotlin/com/github/rushyverse/core/cache/AbstractCacheService.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/cache/AbstractCacheService.kt
@@ -47,7 +47,7 @@ public abstract class AbstractCacheService(
      * @return [String] corresponding to the key using the [prefixKey] and [key].
      */
     protected open fun formattedKeyWithPrefix(key: String, vararg argsFormat: String): String {
-        return prefixKey.format(*argsFormat) + key
+        return (prefixKey + key).format(*argsFormat)
     }
 
     /**

--- a/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
@@ -708,6 +708,7 @@ public class GuildCacheService(
                     guildId.toString(),
                     entityId
                 )
+                // TODO Remove import invitation
                 if (connection.exists(importKey) == 1L) {
                     addValueOfSet(guildId, entityId, Type.REMOVE_INVITATION)
                 } else {

--- a/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
@@ -79,6 +79,10 @@ public data class GuildInvite(
     val createdAt: Instant = Instant.EPOCH,
 ) {
 
+    /**
+     * Check if the invite is expired.
+     * @return `true` if the invite is expired, `false` if it is not.
+     */
     public fun isExpired(): Boolean {
         return expiredAt != null && expiredAt.isBefore(Instant.now())
     }

--- a/src/test/kotlin/com/github/rushyverse/core/cache/CacheClientTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/cache/CacheClientTest.kt
@@ -35,7 +35,7 @@ import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-@Timeout(5, unit = TimeUnit.SECONDS)
+@Timeout(10, unit = TimeUnit.SECONDS)
 @Testcontainers
 class CacheClientTest {
 

--- a/src/test/kotlin/com/github/rushyverse/core/data/friend/FriendCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/friend/FriendCacheServiceTest.kt
@@ -26,7 +26,7 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.test.*
 
-@Timeout(5, unit = TimeUnit.SECONDS)
+@Timeout(10, unit = TimeUnit.SECONDS)
 @Testcontainers
 class FriendCacheServiceTest {
 

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -204,7 +204,7 @@ class GuildCacheServiceTest {
                 repeat(sizeData) {
                     service.addMember(guildId, getRandomString())
                 }
-                service.importInvitations(guildId, List(sizeData) {
+                service.importInvitations(List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
                 })
                 repeat(sizeData) {
@@ -215,15 +215,15 @@ class GuildCacheServiceTest {
                 val guildIdString = guildId.toString()
 
                 assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
                 assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
 
                 assertTrue { service.deleteGuild(guild.id) }
                 assertThat(getAllImportedInvites(guildIdString)).isEmpty()
-                assertThat(getAllAddInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
                 assertThat(getAllImportedMembers(guildIdString)).isEmpty()
-                assertThat(getAllAddMembers(guildIdString)).isEmpty()
+                assertThat(getAllAddedMembers(guildIdString)).isEmpty()
                 assertThat(getAllAddedGuilds()).isEmpty()
             }
 
@@ -239,7 +239,7 @@ class GuildCacheServiceTest {
                 }
                 service.importMembers(guildId, List(sizeData) { getRandomString() })
 
-                service.importInvitations(guildId, List(sizeData) {
+                service.importInvitations(List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
                 })
                 repeat(sizeData) {
@@ -249,16 +249,16 @@ class GuildCacheServiceTest {
                 val guildIdString = guildId.toString()
 
                 assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
                 assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
 
                 assertTrue { service.deleteGuild(guild.id) }
 
                 assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
                 assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
                 assertThat(getAllAddedGuilds()).containsExactly(guild2)
 
                 assertThat(getAllDeletedGuilds()).isEmpty()
@@ -320,7 +320,7 @@ class GuildCacheServiceTest {
                 val importedInvites = List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
                 }
-                service.importInvitations(guildId, importedInvites)
+                service.importInvitations(importedInvites)
                 repeat(sizeData) {
                     service.addInvitation(guildId, getRandomString(), null)
                 }
@@ -328,20 +328,20 @@ class GuildCacheServiceTest {
                 val guildIdString = guildId.toString()
 
                 assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-                assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
                 assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-                assertThat(getAllRemoveMembers(guildIdString)).isEmpty()
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
 
                 assertTrue { service.deleteGuild(guild.id) }
 
                 assertThat(getAllImportedInvites(guildIdString)).isEmpty()
-                assertThat(getAllAddInvites(guildIdString)).isEmpty()
-                assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+                assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
                 assertThat(getAllImportedMembers(guildIdString)).isEmpty()
-                assertThat(getAllAddMembers(guildIdString)).isEmpty()
-                assertThat(getAllRemoveMembers(guildIdString)).isEmpty()
+                assertThat(getAllAddedMembers(guildIdString)).isEmpty()
+                assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
                 assertThat(getAllImportedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
             }
@@ -365,7 +365,7 @@ class GuildCacheServiceTest {
                 val importedInvites = List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
                 }
-                service.importInvitations(guildId, importedInvites)
+                service.importInvitations(importedInvites)
                 repeat(sizeData) {
                     service.addInvitation(guildId, getRandomString(), null)
                 }
@@ -373,20 +373,20 @@ class GuildCacheServiceTest {
                 val guildIdString = guildId.toString()
 
                 assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-                assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
                 assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-                assertThat(getAllRemoveMembers(guildIdString)).isEmpty()
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
 
                 assertTrue { service.deleteGuild(guild.id) }
 
                 assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-                assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
                 assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-                assertThat(getAllRemoveMembers(guildIdString)).isEmpty()
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
                 assertThat(getAllImportedGuilds()).containsExactly(guild2)
 
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
@@ -637,9 +637,9 @@ class GuildCacheServiceTest {
 
                     val guildIdString = guildId.toString()
                     assertThat(getAllImportedInvites(guildIdString)).isEmpty()
-                    assertThat(getAllAddInvites(guildIdString)).hasSize(1)
-                    assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
-                    val inviteForGuild = getAllAddInvites(guildIdString)
+                    assertThat(getAllAddedInvites(guildIdString)).hasSize(1)
+                    assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                    val inviteForGuild = getAllAddedInvites(guildIdString)
 
                     val invite = inviteForGuild.single()
                     assertEquals(entityId, invite.entityId)
@@ -659,9 +659,9 @@ class GuildCacheServiceTest {
 
                     val guildIdString = guildId.toString()
                     assertThat(getAllImportedInvites(guildIdString)).isEmpty()
-                    assertThat(getAllAddInvites(guildIdString)).hasSize(1)
-                    assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
-                    val inviteForGuild = getAllAddInvites(guildIdString)
+                    assertThat(getAllAddedInvites(guildIdString)).hasSize(1)
+                    assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                    val inviteForGuild = getAllAddedInvites(guildIdString)
 
                     val invite = inviteForGuild.single()
                     assertEquals(entityId, invite.entityId)
@@ -705,7 +705,7 @@ class GuildCacheServiceTest {
                     service.addInvitation(guildId, entityId, null)
                 }
 
-                assertThat(getAllAddInvites(guildId.toString())).isEmpty()
+                assertThat(getAllAddedInvites(guildId.toString())).isEmpty()
             }
         }
 
@@ -735,7 +735,7 @@ class GuildCacheServiceTest {
                 assertThrows<GuildInvitedIsAlreadyMemberException> {
                     service.addInvitation(it.id, it.ownerId, null)
                 }
-                assertThat(getAllAddInvites(it.id.toString())).isEmpty()
+                assertThat(getAllAddedInvites(it.id.toString())).isEmpty()
             }
         }
 
@@ -749,7 +749,7 @@ class GuildCacheServiceTest {
                 assertFalse { service.addInvitation(guildId, entityId, null) }
                 assertTrue { service.addInvitation(guildId, entityId, expiredAt) }
 
-                assertThat(getAllAddInvites(guildId.toString())).containsExactly(
+                assertThat(getAllAddedInvites(guildId.toString())).containsExactly(
                     GuildInvite(guildId, entityId, expiredAt)
                 )
             }
@@ -786,14 +786,14 @@ class GuildCacheServiceTest {
                     val entityId = getRandomString()
                     service.addInvitation(guildId, entityId, null)
 
-                    assertThat(getAllAddInvites(guildIdString)).containsExactly(
+                    assertThat(getAllAddedInvites(guildIdString)).containsExactly(
                         GuildInvite(guildId, entityId, null)
                     )
 
                     assertTrue { service.removeInvitation(guildId, entityId) }
 
-                    assertThat(getAllAddInvites(guildIdString)).isEmpty()
-                    assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
+                    assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+                    assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
                     assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                 }
             }
@@ -809,10 +809,10 @@ class GuildCacheServiceTest {
                     service.addInvitation(guildId, entityId, null)
                     assertFalse { service.removeInvitation(guildId, entityId2) }
 
-                    assertThat(getAllAddInvites(guildIdString)).containsExactly(
+                    assertThat(getAllAddedInvites(guildIdString)).containsExactly(
                         GuildInvite(guildId, entityId, null)
                     )
-                    assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
+                    assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
                     assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                 }
             }
@@ -832,7 +832,7 @@ class GuildCacheServiceTest {
                 val entityId = getRandomString()
 
                 val expectedInvite = GuildInvite(guildId, entityId, null)
-                service.importInvitations(guildId, listOf(expectedInvite))
+                service.importInvitations(listOf(expectedInvite))
 
                 assertThat(getAllImportedInvites(guildIdString)).containsExactly(
                     expectedInvite
@@ -840,8 +840,8 @@ class GuildCacheServiceTest {
 
                 assertTrue { service.removeInvitation(guildId, entityId) }
 
-                assertThat(getAllAddInvites(guildIdString)).isEmpty()
-                assertThat(getAllRemoveInvites(guildIdString)).containsExactly(
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+                assertThat(getAllRemovedInvites(guildIdString)).containsExactly(
                     expectedInvite.entityId
                 )
                 assertThat(getAllImportedInvites(guildIdString)).isEmpty()
@@ -858,12 +858,12 @@ class GuildCacheServiceTest {
                 val entityId2 = getRandomString()
 
                 val expectedInvite = GuildInvite(guildId, entityId, null)
-                service.importInvitations(guildId, listOf(expectedInvite))
+                service.importInvitations(listOf(expectedInvite))
 
                 assertFalse { service.removeInvitation(guildId, entityId2) }
 
-                assertThat(getAllAddInvites(guildIdString)).isEmpty()
-                assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+                assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
                 assertThat(getAllImportedInvites(guildIdString)).containsExactly(expectedInvite)
             }
 
@@ -878,8 +878,8 @@ class GuildCacheServiceTest {
             val entityId = getRandomString()
             assertFalse { service.removeInvitation(guildId, entityId) }
 
-            assertThat(getAllAddInvites(guildIdString)).isEmpty()
-            assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+            assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
             assertThat(getAllImportedInvites(guildIdString)).isEmpty()
         }
 
@@ -972,7 +972,7 @@ class GuildCacheServiceTest {
             service.importGuild(guild)
             val guildId = guild.id
             val expectedInvites = List(number) { GuildInvite(guildId, getRandomString(), null) }
-            service.importInvitations(guildId, expectedInvites)
+            service.importInvitations(expectedInvites)
 
             val invites = service.getInvitations(guildId).toList()
             assertThat(invites).containsExactlyInAnyOrderElementsOf(expectedInvites)
@@ -985,7 +985,7 @@ class GuildCacheServiceTest {
             service.importGuild(guild)
             val guildId = guild.id
             val invites = List(number) { GuildInvite(guildId, getRandomString(), null) }
-            service.importInvitations(guildId, invites)
+            service.importInvitations(invites)
 
             invites.forEach { invite ->
                 service.removeInvitation(guildId, invite.entityId)
@@ -1003,7 +1003,7 @@ class GuildCacheServiceTest {
             val guildId = guild.id
 
             val importedInvites = List(number) { GuildInvite(guildId, getRandomString(), null) }
-            service.importInvitations(guildId, importedInvites)
+            service.importInvitations(importedInvites)
 
             val addedInvites = List(number) { GuildInvite(guildId, getRandomString(), null) }.onEach { invite ->
                 service.addInvitation(guildId, invite.entityId, null)
@@ -1011,6 +1011,64 @@ class GuildCacheServiceTest {
 
             val invites = service.getInvitations(guildId).toList()
             assertThat(invites).containsExactlyInAnyOrderElementsOf(importedInvites + addedInvites)
+        }
+    }
+
+    @Nested
+    inner class ImportInvitations {
+
+        @Test
+        fun `with empty list`() = runTest {
+            assertFalse { service.importInvitations(emptyList()) }
+        }
+
+        @Test
+        fun `with one invitation with a non existing guild`() = runTest {
+            val invites = listOf(GuildInvite(0, getRandomString(), null))
+            assertThrows<GuildNotFoundException> {
+                service.importInvitations(invites)
+            }
+        }
+
+        @Test
+        fun `should throw exception if at least one guild is not found`() = runTest {
+            withGuildImportedAndCreated {
+                val guildId = it.id
+                val invites = listOf(
+                    GuildInvite(guildId, getRandomString(), null),
+                    GuildInvite(guildId + 1, getRandomString(), null)
+                )
+                assertThrows<GuildNotFoundException> {
+                    service.importInvitations(invites)
+                }
+
+                val guildIdString = guildId.toString()
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+
+                val guildIdString2 = (guildId + 1).toString()
+                assertThat(getAllImportedInvites(guildIdString2)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString2)).isEmpty()
+            }
+        }
+
+        @Test
+        fun `should throw exception if at least one invitation is expired`() = runTest {
+            withGuildImportedAndCreated {
+                val guildId = it.id
+                val invites = listOf(
+                    GuildInvite(guildId, getRandomString(), null),
+                    GuildInvite(guildId, getRandomString(), Instant.now().minusSeconds(1))
+                )
+
+                assertThrows<IllegalArgumentException> {
+                    service.importInvitations(invites)
+                }
+
+                val guildIdString = guildId.toString()
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+            }
         }
     }
 
@@ -1033,8 +1091,8 @@ class GuildCacheServiceTest {
     private suspend fun getAllDeletedGuilds(): List<Int> {
         val key = (service.prefixCommonKey + GuildCacheService.Type.REMOVE_GUILD.key).encodeToByteArray()
         return cacheClient.connect {
-            it.smembers(key).map {
-                cacheClient.binaryFormat.decodeFromByteArray(Int.serializer(), it)
+            it.smembers(key).map { value ->
+                cacheClient.binaryFormat.decodeFromByteArray(Int.serializer(), value)
             }.toList()
         }
     }
@@ -1043,7 +1101,7 @@ class GuildCacheServiceTest {
         return getAllInvitesWithReplacement(GuildCacheService.Type.IMPORT_INVITATION, guildId)
     }
 
-    private suspend fun getAllAddInvites(guildId: String): List<GuildInvite> {
+    private suspend fun getAllAddedInvites(guildId: String): List<GuildInvite> {
         return getAllInvitesWithReplacement(GuildCacheService.Type.ADD_INVITATION, guildId)
     }
 
@@ -1054,7 +1112,7 @@ class GuildCacheServiceTest {
             }
     }
 
-    private suspend fun getAllRemoveInvites(guildId: String): List<String> {
+    private suspend fun getAllRemovedInvites(guildId: String): List<String> {
         return getAllValuesOfSet(GuildCacheService.Type.REMOVE_INVITATION, guildId).map {
             cacheClient.binaryFormat.decodeFromByteArray(String.serializer(), it)
         }
@@ -1066,13 +1124,13 @@ class GuildCacheServiceTest {
         }
     }
 
-    private suspend fun getAllAddMembers(guildId: String): List<String> {
+    private suspend fun getAllAddedMembers(guildId: String): List<String> {
         return getAllValuesOfSet(GuildCacheService.Type.ADD_MEMBER, guildId).map {
             cacheClient.binaryFormat.decodeFromByteArray(String.serializer(), it)
         }
     }
 
-    private suspend fun getAllRemoveMembers(guildId: String): List<String> {
+    private suspend fun getAllRemovedMembers(guildId: String): List<String> {
         return getAllValuesOfSet(GuildCacheService.Type.REMOVE_MEMBER, guildId).map {
             cacheClient.binaryFormat.decodeFromByteArray(String.serializer(), it)
         }
@@ -1093,7 +1151,6 @@ class GuildCacheServiceTest {
         return cacheClient.connect {
             val scanner = it.scan(KeyScanArgs.Builder.limit(Long.MAX_VALUE).match(searchKey))
             if (scanner == null || scanner.keys.isEmpty()) return emptyList()
-
 
             it.mget(*scanner.keys.toTypedArray())
                 .filter { keyValue -> keyValue.hasValue() }

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -13,7 +13,6 @@ import io.lettuce.core.KeyValue
 import io.lettuce.core.RedisURI
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
@@ -957,7 +956,7 @@ class GuildCacheServiceTest {
             val entityId = getRandomString()
             assertTrue { service.addInvitation(guild.id, entityId, null) }
 
-            val invited = service.getInvited(guild.id).toList()
+            val invited = service.getInvitations(guild.id).toList()
             assertContentEquals(listOf(entityId), invited)
         }
 
@@ -982,8 +981,8 @@ class GuildCacheServiceTest {
             assertTrue { service.addInvitation(guild.id, entityId, null) }
             assertTrue { service.addInvitation(guild2.id, entityId, null) }
 
-            assertEquals(entityId, service.getInvited(guild.id).toList().single())
-            assertEquals(entityId, service.getInvited(guild2.id).toList().single())
+            assertEquals(entityId, service.getInvitations(guild.id).toList().single())
+            assertEquals(entityId, service.getInvitations(guild2.id).toList().single())
         }
 
         @Test
@@ -991,7 +990,7 @@ class GuildCacheServiceTest {
             val guild = service.createGuild(getRandomString(), getRandomString())
             assertTrue { service.addInvitation(guild.id, guild.ownerId, null) }
 
-            val invited = service.getInvited(guild.id).toList()
+            val invited = service.getInvitations(guild.id).toList()
             assertThat(getAllAddInvites(guild.id.toString())).containsExactly(
                 GuildInvite(guild.id, guild.ownerId, null)
             )
@@ -1006,7 +1005,7 @@ class GuildCacheServiceTest {
             assertFalse { service.addInvitation(guild.id, entityId, null) }
             assertTrue { service.addInvitation(guild.id, entityId, expiredAt) }
 
-            val invited = service.getInvited(guild.id).toList()
+            val invited = service.getInvitations(guild.id).toList()
             assertContentEquals(listOf(entityId), invited)
 
             assertThat(getAllAddInvites(guild.id.toString())).containsExactly(

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -2,10 +2,7 @@ package com.github.rushyverse.core.data.guild
 
 import com.github.rushyverse.core.cache.CacheClient
 import com.github.rushyverse.core.container.createRedisContainer
-import com.github.rushyverse.core.data.Guild
-import com.github.rushyverse.core.data.GuildCacheService
-import com.github.rushyverse.core.data.GuildInvite
-import com.github.rushyverse.core.data.GuildNotFoundException
+import com.github.rushyverse.core.data.*
 import com.github.rushyverse.core.utils.getRandomString
 import io.lettuce.core.FlushMode
 import io.lettuce.core.KeyScanArgs
@@ -215,33 +212,16 @@ class GuildCacheServiceTest {
 
                 val guildIdString = guildId.toString()
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
                 assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
                 assertThat(getAllAddMembers(guildIdString)).hasSize(10)
 
                 assertTrue { service.deleteGuild(guild.id) }
-
-                assertFalse { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                 assertThat(getAllAddInvites(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
+                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
                 assertThat(getAllAddMembers(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.ADD_GUILD, guildIdString) }
                 assertThat(getAllAddedGuilds()).isEmpty()
             }
 
@@ -266,33 +246,17 @@ class GuildCacheServiceTest {
 
                 val guildIdString = guildId.toString()
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
                 assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
                 assertThat(getAllAddMembers(guildIdString)).hasSize(10)
 
                 assertTrue { service.deleteGuild(guild.id) }
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
                 assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
                 assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_GUILD, guildIdString) }
                 assertThat(getAllAddedGuilds()).containsExactly(guild2)
 
                 assertFalse { commonKeyExists(GuildCacheService.Type.REMOVE_GUILD) }
@@ -349,65 +313,41 @@ class GuildCacheServiceTest {
                 repeat(sizeData) {
                     service.addMember(guildId, getRandomString())
                 }
-                service.importMembers(guildId, List(sizeData) { getRandomString() })
-                repeat(sizeData) {
-                    service.removeMember(guildId, getRandomString())
+                val importedMembers = List(sizeData) { getRandomString() }
+                service.importMembers(guildId, importedMembers)
+                importedMembers.forEach {
+                    service.removeMember(guildId, it)
                 }
 
-                service.importInvitations(guildId, List(sizeData) {
+                val importedInvites = List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
-                })
+                }
+                service.importInvitations(guildId, importedInvites)
                 repeat(sizeData) {
                     service.addInvitation(guildId, getRandomString(), null)
                 }
-                repeat(sizeData) {
-                    service.removeInvitation(guildId, getRandomString())
+                importedInvites.forEach {
+                    service.removeInvitation(guildId, it.entityId)
                 }
 
                 val guildIdString = guildId.toString()
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
                 assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_INVITATION, guildIdString) }
                 assertThat(getAllRemoveInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
                 assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_MEMBER, guildIdString) }
                 assertThat(getAllRemoveMembers(guildIdString)).hasSize(10)
 
                 assertTrue { service.deleteGuild(guild.id) }
 
-                assertFalse { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                 assertThat(getAllAddInvites(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.REMOVE_INVITATION, guildIdString) }
                 assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
+                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
                 assertThat(getAllAddMembers(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.REMOVE_MEMBER, guildIdString) }
                 assertThat(getAllRemoveMembers(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.IMPORT_GUILD, guildIdString) }
                 assertThat(getAllImportedGuilds()).isEmpty()
-
-                assertTrue { commonKeyExists(GuildCacheService.Type.REMOVE_GUILD) }
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
             }
 
@@ -424,65 +364,42 @@ class GuildCacheServiceTest {
                 repeat(sizeData) {
                     service.addMember(guildId, getRandomString())
                 }
-                service.importMembers(guildId, List(sizeData) { getRandomString() })
-                repeat(sizeData) {
-                    service.removeMember(guildId, getRandomString())
+                val importedMembers = List(sizeData) { getRandomString() }
+                service.importMembers(guildId, importedMembers)
+                importedMembers.forEach {
+                    service.removeMember(guildId, it)
                 }
 
-                service.importInvitations(guildId, List(sizeData) {
+                val importedInvites = List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
-                })
+                }
+                service.importInvitations(guildId, importedInvites)
                 repeat(sizeData) {
                     service.addInvitation(guildId, getRandomString(), null)
                 }
-                repeat(sizeData) {
-                    service.removeInvitation(guildId, getRandomString())
+                importedInvites.forEach {
+                    service.removeInvitation(guildId, it.entityId)
                 }
 
                 val guildIdString = guildId.toString()
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
                 assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_INVITATION, guildIdString) }
                 assertThat(getAllRemoveInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
                 assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_MEMBER, guildIdString) }
                 assertThat(getAllRemoveMembers(guildIdString)).hasSize(10)
 
                 assertTrue { service.deleteGuild(guild.id) }
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
                 assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_INVITATION, guildIdString) }
                 assertThat(getAllRemoveInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
                 assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_MEMBER, guildIdString) }
                 assertThat(getAllRemoveMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_GUILD, guildIdString) }
                 assertThat(getAllImportedGuilds()).containsExactly(guild2)
 
-                assertTrue { commonKeyExists(GuildCacheService.Type.REMOVE_GUILD) }
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
             }
         }
@@ -641,7 +558,7 @@ class GuildCacheServiceTest {
 
         @Test
         fun `with lot of guilds`() = runTest {
-            val numberOfGuilds = 1000
+            val numberOfGuilds = 200
             val name = getRandomString()
             val createdGuild = List(numberOfGuilds) {
                 service.createGuild(
@@ -654,8 +571,7 @@ class GuildCacheServiceTest {
                 Guild(
                     it,
                     name = if (it < numberOfGuilds / 2) name else getRandomString(),
-                    getRandomString(),
-                    Instant.now().truncatedTo(ChronoUnit.MILLIS)
+                    getRandomString()
                 ).apply {
                     service.importGuild(this)
                 }
@@ -908,7 +824,7 @@ class GuildCacheServiceTest {
                 assertTrue { service.addInvitation(guild.id, entityId, expirationDate) }
 
                 val guildIdString = guild.id.toString()
-                assertThat(getAllInvites(guildIdString)).isEmpty()
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                 assertThat(getAllAddInvites(guildIdString)).hasSize(1)
                 assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
                 val inviteForGuild = getAllAddInvites(guild.id.toString())
@@ -928,7 +844,7 @@ class GuildCacheServiceTest {
                 assertTrue { service.addInvitation(guild.id, entityId, null) }
 
                 val guildIdString = guild.id.toString()
-                assertThat(getAllInvites(guildIdString)).isEmpty()
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                 assertThat(getAllAddInvites(guildIdString)).hasSize(1)
                 assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
                 val inviteForGuild = getAllAddInvites(guild.id.toString())
@@ -956,8 +872,10 @@ class GuildCacheServiceTest {
             val entityId = getRandomString()
             assertTrue { service.addInvitation(guild.id, entityId, null) }
 
-            val invited = service.getInvitations(guild.id).toList()
-            assertContentEquals(listOf(entityId), invited)
+            val invitations = service.getInvitations(guild.id).toList()
+            assertThat(invitations).containsExactly(
+                GuildInvite(guild.id, entityId, null)
+            )
         }
 
         @Test
@@ -981,32 +899,31 @@ class GuildCacheServiceTest {
             assertTrue { service.addInvitation(guild.id, entityId, null) }
             assertTrue { service.addInvitation(guild2.id, entityId, null) }
 
-            assertEquals(entityId, service.getInvitations(guild.id).toList().single())
-            assertEquals(entityId, service.getInvitations(guild2.id).toList().single())
+            assertThat(service.getInvitations(guild.id).toList()).containsExactly(
+                GuildInvite(guild.id, entityId, null)
+            )
+            assertThat(service.getInvitations(guild2.id).toList()).containsExactly(
+                GuildInvite(guild2.id, entityId, null)
+            )
         }
 
         @Test
         fun `when entity is owner of a guild`() = runTest {
             val guild = service.createGuild(getRandomString(), getRandomString())
-            assertTrue { service.addInvitation(guild.id, guild.ownerId, null) }
-
-            val invited = service.getInvitations(guild.id).toList()
-            assertThat(getAllAddInvites(guild.id.toString())).containsExactly(
-                GuildInvite(guild.id, guild.ownerId, null)
-            )
+            assertThrows<GuildInvitedIsAlreadyMemberException> {
+                service.addInvitation(guild.id, guild.ownerId, null)
+            }
+            assertThat(getAllAddInvites(guild.id.toString())).isEmpty()
         }
 
         @Test
         fun `when entity is already invited`() = runTest {
             val guild = service.createGuild(getRandomString(), getRandomString())
             val entityId = getRandomString()
-            val expiredAt = Instant.now().plusSeconds(10)
+            val expiredAt = Instant.now().plusSeconds(10).truncatedTo(ChronoUnit.SECONDS)
             assertTrue { service.addInvitation(guild.id, entityId, null) }
             assertFalse { service.addInvitation(guild.id, entityId, null) }
             assertTrue { service.addInvitation(guild.id, entityId, expiredAt) }
-
-            val invited = service.getInvitations(guild.id).toList()
-            assertContentEquals(listOf(entityId), invited)
 
             assertThat(getAllAddInvites(guild.id.toString())).containsExactly(
                 GuildInvite(guild.id, entityId, expiredAt)
@@ -1031,13 +948,17 @@ class GuildCacheServiceTest {
     }
 
     private suspend fun getAllImportedGuilds(): List<Guild> {
-        return getAllDataFromKey(GuildCacheService.Type.IMPORT_GUILD).map { keyValue ->
+        return getAllDataFromKey(GuildCacheService.Type.IMPORT_GUILD, "*").filter {
+            it.key.decodeToString().endsWith(GuildCacheService.Type.IMPORT_GUILD.key)
+        }.map { keyValue ->
             cacheClient.binaryFormat.decodeFromByteArray(Guild.serializer(), keyValue.value)
         }
     }
 
     private suspend fun getAllAddedGuilds(): List<Guild> {
-        return getAllDataFromKey(GuildCacheService.Type.ADD_GUILD).map { keyValue ->
+        return getAllDataFromKey(GuildCacheService.Type.ADD_GUILD, "*").filter {
+            it.key.decodeToString().endsWith(GuildCacheService.Type.ADD_GUILD.key)
+        }.map { keyValue ->
             cacheClient.binaryFormat.decodeFromByteArray(Guild.serializer(), keyValue.value)
         }
     }
@@ -1051,8 +972,11 @@ class GuildCacheServiceTest {
         }
     }
 
-    private suspend fun keyExists(type: GuildCacheService.Type, guildId: String): Boolean {
-        val key = service.prefixKey.format(guildId) + type.key
+    private suspend fun keyExists(
+        type: GuildCacheService.Type,
+        vararg format: String
+    ): Boolean {
+        val key = (service.prefixKey + type.key).format(*format)
         return keyExists(key)
     }
 
@@ -1067,16 +991,22 @@ class GuildCacheServiceTest {
         } == 1L
     }
 
-    private suspend fun getAllInvites(guildId: String): List<GuildInvite> {
-        return getAllValuesOfSet(GuildCacheService.Type.IMPORT_INVITATION, guildId).map {
-            cacheClient.binaryFormat.decodeFromByteArray(GuildInvite.serializer(), it)
-        }
+    private suspend fun getAllImportedInvites(guildId: String): List<GuildInvite> {
+        return getAllInvitesWithReplacement(GuildCacheService.Type.IMPORT_INVITATION, guildId)
     }
 
     private suspend fun getAllAddInvites(guildId: String): List<GuildInvite> {
-        return getAllValuesOfSet(GuildCacheService.Type.ADD_INVITATION, guildId).map {
-            cacheClient.binaryFormat.decodeFromByteArray(GuildInvite.serializer(), it)
-        }
+        return getAllInvitesWithReplacement(GuildCacheService.Type.ADD_INVITATION, guildId)
+    }
+
+    private suspend fun getAllInvitesWithReplacement(type: GuildCacheService.Type, guildId: String): List<GuildInvite> {
+        val regexEnd = Regex(".*${type.key.replace("%s", "[^:]+")}\$")
+        return getAllDataFromKey(type, guildId, "*")
+            .filter {
+                regexEnd.matches(it.key.decodeToString())
+            }.map { keyValue ->
+                cacheClient.binaryFormat.decodeFromByteArray(GuildInvite.serializer(), keyValue.value)
+            }
     }
 
     private suspend fun getAllRemoveInvites(guildId: String): List<String> {
@@ -1085,7 +1015,7 @@ class GuildCacheServiceTest {
         }
     }
 
-    private suspend fun getAllMembers(guildId: String): List<String> {
+    private suspend fun getAllImportedMembers(guildId: String): List<String> {
         return getAllValuesOfSet(GuildCacheService.Type.IMPORT_MEMBER, guildId).map {
             cacheClient.binaryFormat.decodeFromByteArray(String.serializer(), it)
         }
@@ -1111,9 +1041,10 @@ class GuildCacheServiceTest {
     }
 
     private suspend fun getAllDataFromKey(
-        type: GuildCacheService.Type
+        type: GuildCacheService.Type,
+        vararg format: String
     ): List<KeyValue<ByteArray, ByteArray>> {
-        val searchKey = service.prefixKey.format("*") + type.key
+        val searchKey = (service.prefixKey + type.key).format(*format)
         return cacheClient.connect {
             val scanner = it.scan(KeyScanArgs.Builder.limit(Long.MAX_VALUE).match(searchKey))
             if (scanner == null || scanner.keys.isEmpty()) return emptyList()

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -713,11 +713,11 @@ class GuildCacheServiceTest {
                 val guildId = it.id
                 val entityId = getRandomString()
                 assertTrue { service.addMember(guildId, entityId) }
-                assertTrue { service.addInvitation(guildId, entityId, null) }
+                assertThrows<GuildInvitedIsAlreadyMemberException> {
+                    service.addInvitation(guildId, entityId, null)
+                }
 
-                assertThat(getAllAddInvites(guildId.toString())).containsExactly(
-                    GuildInvite(guildId, entityId, null)
-                )
+                assertThat(getAllAddInvites(guildId.toString())).isEmpty()
             }
         }
 
@@ -807,12 +807,6 @@ class GuildCacheServiceTest {
                 cacheClient.binaryFormat.decodeFromByteArray(Int.serializer(), it)
             }.toList()
         }
-    }
-
-    private suspend fun keyExists(key: String): Boolean {
-        return cacheClient.connect {
-            it.exists(key.encodeToByteArray())
-        } == 1L
     }
 
     private suspend fun getAllImportedInvites(guildId: String): List<GuildInvite> {

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildDatabaseServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildDatabaseServiceTest.kt
@@ -6,7 +6,6 @@ import com.github.rushyverse.core.data.utils.DatabaseUtils
 import com.github.rushyverse.core.data.utils.DatabaseUtils.createConnectionOptions
 import com.github.rushyverse.core.data.utils.MicroClockProvider
 import com.github.rushyverse.core.utils.getRandomString
-import io.r2dbc.spi.R2dbcDataIntegrityViolationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
@@ -435,7 +434,7 @@ class GuildDatabaseServiceTest {
             val members = service.getMembers(guild.id).toList()
             assertThat(members).containsExactlyInAnyOrder(owner, entityId)
 
-            val pendingMembers = service.getInvited(guild.id).toList()
+            val pendingMembers = service.getInvitations(guild.id).toList()
             assertThat(pendingMembers).isEmpty()
         }
 
@@ -567,7 +566,7 @@ class GuildDatabaseServiceTest {
             val entityId = getRandomString()
             assertTrue { service.addInvitation(guild.id, entityId, null) }
 
-            val invited = service.getInvited(guild.id).toList()
+            val invited = service.getInvitations(guild.id).toList()
             assertContentEquals(listOf(entityId), invited)
         }
 
@@ -580,7 +579,7 @@ class GuildDatabaseServiceTest {
                 service.addInvitation(guild.id, entityId, null)
             }
 
-            val invited = service.getInvited(guild.id).toList()
+            val invited = service.getInvitations(guild.id).toList()
             assertEquals(0, invited.size)
         }
 
@@ -593,8 +592,8 @@ class GuildDatabaseServiceTest {
             assertTrue { service.addInvitation(guild.id, entityId, null) }
             assertTrue { service.addInvitation(guild2.id, entityId, null) }
 
-            assertEquals(entityId, service.getInvited(guild.id).toList().single())
-            assertEquals(entityId, service.getInvited(guild2.id).toList().single())
+            assertEquals(entityId, service.getInvitations(guild.id).toList().single())
+            assertEquals(entityId, service.getInvitations(guild2.id).toList().single())
         }
 
         @Test
@@ -604,7 +603,7 @@ class GuildDatabaseServiceTest {
                 service.addInvitation(guild.id, guild.ownerId, null)
             }
 
-            val invited = service.getInvited(guild.id).toList()
+            val invited = service.getInvitations(guild.id).toList()
             assertEquals(0, invited.size)
         }
 
@@ -799,7 +798,7 @@ class GuildDatabaseServiceTest {
             service.addInvitation(guild.id, entityId, null)
             assertTrue { service.removeInvitation(guild.id, entityId) }
 
-            val invites = service.getInvited(guild.id).toList()
+            val invites = service.getInvitations(guild.id).toList()
             assertContentEquals(emptyList(), invites)
         }
 
@@ -809,7 +808,7 @@ class GuildDatabaseServiceTest {
             val entityId = getRandomString()
             assertFalse { service.removeInvitation(guild.id, entityId) }
 
-            val invites = service.getInvited(guild.id).toList()
+            val invites = service.getInvitations(guild.id).toList()
             assertContentEquals(emptyList(), invites)
         }
 
@@ -821,7 +820,7 @@ class GuildDatabaseServiceTest {
             service.addInvitation(guild.id, entityId, null)
             assertFalse { service.removeInvitation(guild.id, entityId2) }
 
-            val invites = service.getInvited(guild.id).toList()
+            val invites = service.getInvitations(guild.id).toList()
             assertContentEquals(listOf(entityId), invites)
         }
 
@@ -892,7 +891,7 @@ class GuildDatabaseServiceTest {
         fun `when guild has no invitations`() = runTest {
             val owner = getRandomString()
             val guild = service.createGuild(getRandomString(), owner)
-            val members = service.getInvited(guild.id).toList()
+            val members = service.getInvitations(guild.id).toList()
             assertContentEquals(emptyList(), members)
         }
 
@@ -903,7 +902,7 @@ class GuildDatabaseServiceTest {
             val membersToAdd = listOf(getRandomString(), getRandomString())
             membersToAdd.forEach { service.addInvitation(guild.id, it, null) }
 
-            val members = service.getInvited(guild.id).toList()
+            val members = service.getInvitations(guild.id).toList()
             assertContentEquals(membersToAdd, members)
         }
 
@@ -913,13 +912,13 @@ class GuildDatabaseServiceTest {
             val guild = service.createGuild(getRandomString(), owner)
             service.addMember(guild.id, getRandomString())
 
-            val members = service.getInvited(guild.id).toList()
+            val members = service.getInvitations(guild.id).toList()
             assertContentEquals(emptyList(), members)
         }
 
         @Test
         fun `when guild does not exist`() = runTest {
-            val members = service.getInvited(0).toList()
+            val members = service.getInvitations(0).toList()
             assertContentEquals(emptyList(), members)
         }
     }


### PR DESCRIPTION
# Context

The interface allows to insert a new invitation with an expiration time.
However, the current implementation doesn't allow registering this value.
So, we need to change the way to register a new invitation

**Before**
| Key                 | Values                         |
|----------------|-------------------------|
| guild:X:invite |  Set of entities invited | 

**Now**
| Key                                   | Values                         |
|----------------------------|-------------------------|
| guild:X:invite:entityId |  Invitation serialized | 
| guild:X:invite:entityId2 |  Invitation serialized | 
| guild:X:invite:entityId3 |  Invitation serialized | 
| guild:X:invite:entityId4 |  Invitation serialized | 

So the new  solution is to create as many keys as there are invitations for a guild