### PR TITLE
fix: rules guild cache

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/core/cache/AbstractCacheService.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/cache/AbstractCacheService.kt
@@ -35,8 +35,19 @@ public abstract class AbstractCacheService(
      * @param argsFormat The arguments to use to format [prefixKey].
      * @return [ByteArray] corresponding to the key using the [prefixKey] and [key].
      */
-    protected open fun encodeFormattedKeyUsingPrefix(key: String, vararg argsFormat: String): ByteArray {
-        return encodeKey(prefixKey.format(*argsFormat) + key)
+    protected open fun encodeFormattedKeyWithPrefix(key: String, vararg argsFormat: String): ByteArray {
+        return encodeKey(formattedKeyWithPrefix(key, *argsFormat))
+    }
+
+    /**
+     * Use [argsFormat] to format [prefixKey] before concatenating it with [key].
+     * The result will be the final key used to identify data in cache.
+     * @param key The key to use.
+     * @param argsFormat The arguments to use to format [prefixKey].
+     * @return [String] corresponding to the key using the [prefixKey] and [key].
+     */
+    protected open fun formattedKeyWithPrefix(key: String, vararg argsFormat: String): String {
+        return prefixKey.format(*argsFormat) + key
     }
 
     /**
@@ -44,8 +55,17 @@ public abstract class AbstractCacheService(
      * @param key Value using to create key.
      * @return [ByteArray] corresponding to the key using the [prefixKey] and [key].
      */
-    protected open fun encodeKeyUsingPrefix(key: String): ByteArray {
-        return encodeKey(prefixKey + key)
+    protected open fun encodeKeyWithPrefix(key: String): ByteArray {
+        return encodeKey(keyWithPrefix(key))
+    }
+
+    /**
+     * Create the key from a [String] value to identify data in cache.
+     * @param key Value using to create key.
+     * @return [String] corresponding to the key using the [prefixKey] and [key].
+     */
+    protected open fun keyWithPrefix(key: String): String {
+        return prefixKey + key
     }
 
     /**

--- a/src/main/kotlin/com/github/rushyverse/core/cache/AbstractCacheService.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/cache/AbstractCacheService.kt
@@ -47,7 +47,7 @@ public abstract class AbstractCacheService(
      * @return [String] corresponding to the key using the [prefixKey] and [key].
      */
     protected open fun formattedKeyWithPrefix(key: String, vararg argsFormat: String): String {
-        return prefixKey.format(*argsFormat) + key
+        return (prefixKey + key).format(*argsFormat)
     }
 
     /**
@@ -136,9 +136,9 @@ public abstract class AbstractCacheService(
             var cursor = connection.scan(scanArgs)
             while (cursor != null && currentCoroutineContext().isActive) {
                 val keys = cursor.keys
-                if (keys.isEmpty()) break
-
-                emitAll(builder(connection, keys))
+                if (keys.isNotEmpty()) {
+                    emitAll(builder(connection, keys))
+                }
                 if (cursor.isFinished) break
 
                 cursor = connection.scan(cursor, scanArgs)

--- a/src/main/kotlin/com/github/rushyverse/core/data/Friend.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Friend.kt
@@ -338,7 +338,7 @@ public class FriendCacheService(
     }
 
     override fun getAll(uuid: UUID, type: Type): Flow<UUID> = flow {
-        val key = encodeFormattedKeyUsingPrefix(type.key, uuid.toString())
+        val key = encodeFormattedKeyWithPrefix(type.key, uuid.toString())
 
         cacheClient.connect { connection ->
             connection.smembers(key)
@@ -405,7 +405,7 @@ public class FriendCacheService(
         friend: UUID,
         type: Type
     ): Boolean {
-        val key = encodeFormattedKeyUsingPrefix(type.key, uuid.toString())
+        val key = encodeFormattedKeyWithPrefix(type.key, uuid.toString())
         val value = encodeToByteArray(UUIDSerializer, friend)
         return connection.sismember(key, value) == true
     }
@@ -427,7 +427,7 @@ public class FriendCacheService(
         if (friends.isEmpty()) return true
 
         val size = friends.size
-        val key = encodeFormattedKeyUsingPrefix(type.key, uuid.toString())
+        val key = encodeFormattedKeyWithPrefix(type.key, uuid.toString())
         val friendsSerialized = friends.asSequence().map { encodeToByteArray(UUIDSerializer, it) }.toTypedArray(size)
 
         val result = connection.sadd(key, *friendsSerialized)
@@ -448,7 +448,7 @@ public class FriendCacheService(
         friend: UUID,
         type: Type
     ): Boolean {
-        val key = encodeFormattedKeyUsingPrefix(type.key, uuid.toString())
+        val key = encodeFormattedKeyWithPrefix(type.key, uuid.toString())
         val value = encodeToByteArray(UUIDSerializer, friend)
         val result = connection.srem(key, value)
         return result != null && result > 0
@@ -490,7 +490,7 @@ public class FriendCacheService(
         type: Type
     ): Boolean {
         return cacheClient.connect {
-            it.del(encodeFormattedKeyUsingPrefix(type.key, uuid.toString()))
+            it.del(encodeFormattedKeyWithPrefix(type.key, uuid.toString()))
             add(it, uuid, friends, type)
         }
     }

--- a/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
@@ -539,7 +539,7 @@ public class GuildCacheService(
         return if (isCacheGuild(id)) {
             deleteGuildData(id)
         } else {
-            addMarkGuildAsDeleted(id)
+            hasGuild(id) && addMarkGuildAsDeleted(id)
         }
     }
 

--- a/src/main/kotlin/com/github/rushyverse/core/data/ProfileId.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/ProfileId.kt
@@ -44,14 +44,14 @@ public class ProfileIdCacheService(
 ) : AbstractCacheService(client, prefixKey, expirationKey), IProfileIdCacheService {
 
     override suspend fun getIdByName(name: String): ProfileId? {
-        val key = encodeKeyUsingPrefix(name)
+        val key = encodeKeyWithPrefix(name)
         val dataSerial = cacheClient.connect { it.get(key) } ?: return null
         val uuid = decodeFromByteArrayOrNull(String.serializer(), dataSerial) ?: return null
         return ProfileId(id = uuid, name = name)
     }
 
     override suspend fun save(profile: ProfileId) {
-        val key = encodeKeyUsingPrefix(profile.name)
+        val key = encodeKeyWithPrefix(profile.name)
         val value = encodeToByteArray(String.serializer(), profile.id)
         cacheClient.connect {
             setWithExpiration(it, key, value)

--- a/src/main/kotlin/com/github/rushyverse/core/data/ProfileSkin.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/ProfileSkin.kt
@@ -44,13 +44,13 @@ public class ProfileSkinCacheService(
 ) : AbstractCacheService(client, prefixKey, expirationKey), IProfileSkinCacheService {
 
     override suspend fun getSkinById(id: String): ProfileSkin? {
-        val key = encodeKeyUsingPrefix(id)
+        val key = encodeKeyWithPrefix(id)
         val dataSerial = cacheClient.connect { it.get(key) } ?: return null
         return decodeFromByteArrayOrNull(ProfileSkin.serializer(), dataSerial)
     }
 
     override suspend fun save(profile: ProfileSkin) {
-        val key = encodeKeyUsingPrefix(profile.id)
+        val key = encodeKeyWithPrefix(profile.id)
         val value = encodeToByteArray(ProfileSkin.serializer(), profile)
         cacheClient.connect {
             setWithExpiration(it, key, value)

--- a/src/test/kotlin/com/github/rushyverse/core/cache/AbstractCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/cache/AbstractCacheServiceTest.kt
@@ -64,7 +64,7 @@ class AbstractCacheServiceTest {
         fun `with empty prefix key should be the key`() {
             val key = getRandomString()
             val cacheService = object : AbstractCacheService(cacheClient, "") {
-                fun function() = encodeFormattedKeyUsingPrefix(key)
+                fun function() = encodeFormattedKeyWithPrefix(key)
             }
 
             val encodedKey = cacheService.function()
@@ -79,7 +79,7 @@ class AbstractCacheServiceTest {
         fun `with empty key should be the prefix key`() {
             val prefixKey = getRandomString()
             val cacheService = object : AbstractCacheService(cacheClient, prefixKey) {
-                fun function() = encodeFormattedKeyUsingPrefix("")
+                fun function() = encodeFormattedKeyWithPrefix("")
             }
 
             val encodedKey = cacheService.function()
@@ -93,7 +93,7 @@ class AbstractCacheServiceTest {
         @Test
         fun `with empty key and empty prefix key should be empty string`() {
             val cacheService = object : AbstractCacheService(cacheClient, "") {
-                fun function() = encodeFormattedKeyUsingPrefix("")
+                fun function() = encodeFormattedKeyWithPrefix("")
             }
 
             val encodedKey = cacheService.function()
@@ -109,7 +109,7 @@ class AbstractCacheServiceTest {
             val key = getRandomString()
             val prefixKey = getRandomString()
             val cacheService = object : AbstractCacheService(cacheClient, "$prefixKey:%s:") {
-                fun function() = encodeFormattedKeyUsingPrefix(key)
+                fun function() = encodeFormattedKeyWithPrefix(key)
             }
 
             assertThrows<MissingFormatArgumentException> {
@@ -122,7 +122,7 @@ class AbstractCacheServiceTest {
             val key = getRandomString()
             val prefixKey = getRandomString()
             val cacheService = object : AbstractCacheService(cacheClient, "$prefixKey:") {
-                fun function() = encodeFormattedKeyUsingPrefix(key)
+                fun function() = encodeFormattedKeyWithPrefix(key)
             }
             val expected = "$prefixKey:$key"
 
@@ -140,7 +140,7 @@ class AbstractCacheServiceTest {
             val key = getRandomString()
             val prefixKey = getRandomString()
             val cacheService = object : AbstractCacheService(cacheClient, "$prefixKey:%s:") {
-                fun function() = encodeFormattedKeyUsingPrefix(key, argsFormat = arrayOf(user))
+                fun function() = encodeFormattedKeyWithPrefix(key, argsFormat = arrayOf(user))
             }
             val expected = "$prefixKey:$user:$key"
 
@@ -159,7 +159,7 @@ class AbstractCacheServiceTest {
             val key = getRandomString()
             val prefixKey = getRandomString()
             val cacheService = object : AbstractCacheService(cacheClient, "$prefixKey:%s:%s:") {
-                fun function() = encodeFormattedKeyUsingPrefix(key, argsFormat = arrayOf(user, guild))
+                fun function() = encodeFormattedKeyWithPrefix(key, argsFormat = arrayOf(user, guild))
             }
             val expected = "$prefixKey:$user:$guild:$key"
 
@@ -178,7 +178,7 @@ class AbstractCacheServiceTest {
             val prefixKey = getRandomString()
             val cacheService = object : AbstractCacheService(cacheClient, "$prefixKey:%s:") {
                 fun function() =
-                    encodeFormattedKeyUsingPrefix(key, argsFormat = arrayOf(user, getRandomString(), getRandomString()))
+                    encodeFormattedKeyWithPrefix(key, argsFormat = arrayOf(user, getRandomString(), getRandomString()))
             }
             val expected = "$prefixKey:$user:$key"
 
@@ -199,7 +199,7 @@ class AbstractCacheServiceTest {
         fun `with empty prefix key should be the key`() {
             val key = getRandomString()
             val cacheService = object : AbstractCacheService(cacheClient, "") {
-                fun function() = encodeKeyUsingPrefix(key)
+                fun function() = encodeKeyWithPrefix(key)
             }
 
             val encodedKey = cacheService.function()
@@ -214,7 +214,7 @@ class AbstractCacheServiceTest {
         fun `with empty key should be the prefix key`() {
             val prefixKey = getRandomString()
             val cacheService = object : AbstractCacheService(cacheClient, prefixKey) {
-                fun function() = encodeKeyUsingPrefix("")
+                fun function() = encodeKeyWithPrefix("")
             }
 
             val encodedKey = cacheService.function()
@@ -228,7 +228,7 @@ class AbstractCacheServiceTest {
         @Test
         fun `with empty key and empty prefix key should be empty string`() {
             val cacheService = object : AbstractCacheService(cacheClient, "") {
-                fun function() = encodeKeyUsingPrefix("")
+                fun function() = encodeKeyWithPrefix("")
             }
 
             val encodedKey = cacheService.function()
@@ -244,7 +244,7 @@ class AbstractCacheServiceTest {
             val key = getRandomString()
             val prefixKey = getRandomString()
             val cacheService = object : AbstractCacheService(cacheClient, prefixKey) {
-                fun function() = encodeKeyUsingPrefix(key)
+                fun function() = encodeKeyWithPrefix(key)
             }
             val expected = "$prefixKey$key"
 

--- a/src/test/kotlin/com/github/rushyverse/core/cache/CacheClientTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/cache/CacheClientTest.kt
@@ -35,7 +35,7 @@ import kotlin.test.*
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-@Timeout(5, unit = TimeUnit.SECONDS)
+@Timeout(10, unit = TimeUnit.SECONDS)
 @Testcontainers
 class CacheClientTest {
 

--- a/src/test/kotlin/com/github/rushyverse/core/data/friend/FriendCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/friend/FriendCacheServiceTest.kt
@@ -26,7 +26,7 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.test.*
 
-@Timeout(5, unit = TimeUnit.SECONDS)
+@Timeout(10, unit = TimeUnit.SECONDS)
 @Testcontainers
 class FriendCacheServiceTest {
 

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -687,9 +687,7 @@ class GuildCacheServiceTest {
 
     private suspend fun keyExists(type: GuildCacheService.Type, guildId: String): Boolean {
         val key = service.prefixKey.format(guildId) + type.key
-        return keyExists(key).apply {
-            println("Exists: $key = $this")
-        }
+        return keyExists(key)
     }
 
     private suspend fun keyExists(key: String): Boolean {

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -2,10 +2,7 @@ package com.github.rushyverse.core.data.guild
 
 import com.github.rushyverse.core.cache.CacheClient
 import com.github.rushyverse.core.container.createRedisContainer
-import com.github.rushyverse.core.data.Guild
-import com.github.rushyverse.core.data.GuildCacheService
-import com.github.rushyverse.core.data.GuildInvite
-import com.github.rushyverse.core.data.GuildNotFoundException
+import com.github.rushyverse.core.data.*
 import com.github.rushyverse.core.utils.getRandomString
 import io.lettuce.core.FlushMode
 import io.lettuce.core.KeyScanArgs
@@ -13,7 +10,6 @@ import io.lettuce.core.KeyValue
 import io.lettuce.core.RedisURI
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
@@ -21,6 +17,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.builtins.serializer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
@@ -28,9 +25,10 @@ import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
 import kotlin.test.*
 
-//@Timeout(10, unit = TimeUnit.SECONDS)
+@Timeout(10, unit = TimeUnit.SECONDS)
 @Testcontainers
 class GuildCacheServiceTest {
 
@@ -206,7 +204,7 @@ class GuildCacheServiceTest {
                 repeat(sizeData) {
                     service.addMember(guildId, getRandomString())
                 }
-                service.importInvitations(guildId, List(sizeData) {
+                service.importInvitations(List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
                 })
                 repeat(sizeData) {
@@ -216,33 +214,16 @@ class GuildCacheServiceTest {
 
                 val guildIdString = guildId.toString()
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
 
                 assertTrue { service.deleteGuild(guild.id) }
-
-                assertFalse { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
-                assertThat(getAllAddInvites(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
-                assertThat(getAllAddMembers(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.ADD_GUILD, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
+                assertThat(getAllAddedMembers(guildIdString)).isEmpty()
                 assertThat(getAllAddedGuilds()).isEmpty()
             }
 
@@ -258,7 +239,7 @@ class GuildCacheServiceTest {
                 }
                 service.importMembers(guildId, List(sizeData) { getRandomString() })
 
-                service.importInvitations(guildId, List(sizeData) {
+                service.importInvitations(List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
                 })
                 repeat(sizeData) {
@@ -267,36 +248,19 @@ class GuildCacheServiceTest {
 
                 val guildIdString = guildId.toString()
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
 
                 assertTrue { service.deleteGuild(guild.id) }
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_GUILD, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
                 assertThat(getAllAddedGuilds()).containsExactly(guild2)
 
-                assertFalse { commonKeyExists(GuildCacheService.Type.REMOVE_GUILD) }
                 assertThat(getAllDeletedGuilds()).isEmpty()
             }
 
@@ -350,65 +314,35 @@ class GuildCacheServiceTest {
                 repeat(sizeData) {
                     service.addMember(guildId, getRandomString())
                 }
-                service.importMembers(guildId, List(sizeData) { getRandomString() })
-                repeat(sizeData) {
-                    service.removeMember(guildId, getRandomString())
-                }
+                val importedMembers = List(sizeData) { getRandomString() }
+                service.importMembers(guildId, importedMembers)
 
-                service.importInvitations(guildId, List(sizeData) {
+                val importedInvites = List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
-                })
+                }
+                service.importInvitations(importedInvites)
                 repeat(sizeData) {
                     service.addInvitation(guildId, getRandomString(), null)
-                }
-                repeat(sizeData) {
-                    service.removeInvitation(guildId, getRandomString())
                 }
 
                 val guildIdString = guildId.toString()
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_INVITATION, guildIdString) }
-                assertThat(getAllRemoveInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_MEMBER, guildIdString) }
-                assertThat(getAllRemoveMembers(guildIdString)).hasSize(10)
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
 
                 assertTrue { service.deleteGuild(guild.id) }
 
-                assertFalse { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
-                assertThat(getAllAddInvites(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.REMOVE_INVITATION, guildIdString) }
-                assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
-                assertThat(getAllAddMembers(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.REMOVE_MEMBER, guildIdString) }
-                assertThat(getAllRemoveMembers(guildIdString)).isEmpty()
-
-                assertFalse { keyExists(GuildCacheService.Type.IMPORT_GUILD, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+                assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
+                assertThat(getAllAddedMembers(guildIdString)).isEmpty()
+                assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
                 assertThat(getAllImportedGuilds()).isEmpty()
-
-                assertTrue { commonKeyExists(GuildCacheService.Type.REMOVE_GUILD) }
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
             }
 
@@ -425,65 +359,36 @@ class GuildCacheServiceTest {
                 repeat(sizeData) {
                     service.addMember(guildId, getRandomString())
                 }
-                service.importMembers(guildId, List(sizeData) { getRandomString() })
-                repeat(sizeData) {
-                    service.removeMember(guildId, getRandomString())
-                }
+                val importedMembers = List(sizeData) { getRandomString() }
+                service.importMembers(guildId, importedMembers)
 
-                service.importInvitations(guildId, List(sizeData) {
+                val importedInvites = List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
-                })
+                }
+                service.importInvitations(importedInvites)
                 repeat(sizeData) {
                     service.addInvitation(guildId, getRandomString(), null)
-                }
-                repeat(sizeData) {
-                    service.removeInvitation(guildId, getRandomString())
                 }
 
                 val guildIdString = guildId.toString()
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_INVITATION, guildIdString) }
-                assertThat(getAllRemoveInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_MEMBER, guildIdString) }
-                assertThat(getAllRemoveMembers(guildIdString)).hasSize(10)
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
 
                 assertTrue { service.deleteGuild(guild.id) }
 
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_INVITATION, guildIdString) }
-                assertThat(getAllInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_INVITATION, guildIdString) }
-                assertThat(getAllAddInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_INVITATION, guildIdString) }
-                assertThat(getAllRemoveInvites(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_MEMBER, guildIdString) }
-                assertThat(getAllMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.ADD_MEMBER, guildIdString) }
-                assertThat(getAllAddMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.REMOVE_MEMBER, guildIdString) }
-                assertThat(getAllRemoveMembers(guildIdString)).hasSize(10)
-
-                assertTrue { keyExists(GuildCacheService.Type.IMPORT_GUILD, guildIdString) }
+                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
                 assertThat(getAllImportedGuilds()).containsExactly(guild2)
 
-                assertTrue { commonKeyExists(GuildCacheService.Type.REMOVE_GUILD) }
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
             }
         }
@@ -501,63 +406,28 @@ class GuildCacheServiceTest {
     @Nested
     inner class GetGuildById {
 
-        @Nested
-        inner class WithCacheGuild {
-
-            @Test
-            fun `when guild is not deleted`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
-                assertEquals(guild, service.getGuild(guild.id))
+        @Test
+        fun `when guild is not deleted`() = runTest {
+            withGuildImportedAndCreated {
+                assertEquals(it, service.getGuild(it.id))
             }
-
-            @Test
-            fun `when guild is deleted`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
-                service.deleteGuild(guild.id)
-                assertNull(service.getGuild(guild.id))
-            }
-
-            @Test
-            fun `when another guild is added`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
-                val guild2 = service.createGuild(getRandomString(), getRandomString())
-
-                assertEquals(guild, service.getGuild(guild.id))
-                assertEquals(guild2, service.getGuild(guild2.id))
-            }
-
         }
 
-        @Nested
-        inner class WithImportedGuild {
-
-            @Test
-            fun `when guild is not deleted`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString(), Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                service.importGuild(guild)
-                assertEquals(guild, service.getGuild(guild.id))
+        @Test
+        fun `when guild is deleted`() = runTest {
+            withGuildImportedAndCreated {
+                service.deleteGuild(it.id)
+                assertNull(service.getGuild(it.id))
             }
+        }
 
-            @Test
-            fun `when guild is deleted`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString(), Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                service.importGuild(guild)
-                service.deleteGuild(guild.id)
-                assertNull(service.getGuild(guild.id))
-            }
-
-            @Test
-            fun `when another guild is added`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString(), Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                val guild2 =
-                    Guild(1, getRandomString(), getRandomString(), Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                service.importGuild(guild)
-                service.importGuild(guild2)
-
-                assertEquals(guild, service.getGuild(guild.id))
+        @Test
+        fun `when another guild is added`() = runTest {
+            withGuildImportedAndCreated {
+                val guild2 = service.createGuild(getRandomString(), getRandomString())
+                assertEquals(it, service.getGuild(it.id))
                 assertEquals(guild2, service.getGuild(guild2.id))
             }
-
         }
 
         @Test
@@ -569,62 +439,28 @@ class GuildCacheServiceTest {
     @Nested
     inner class GetGuildByName {
 
-        @Nested
-        inner class WithImportedGuild {
-
-            @Test
-            fun `when guild is not deleted`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString(), Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                service.importGuild(guild)
-                assertThat(service.getGuild(guild.name).toList()).containsExactly(guild)
+        @Test
+        fun `when guild is not deleted`() = runTest {
+            withGuildImportedAndCreated {
+                assertThat(service.getGuild(it.name).toList()).containsExactly(it)
             }
-
-            @Test
-            fun `when guild is deleted`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString(), Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                service.importGuild(guild)
-                service.deleteGuild(guild.id)
-                assertThat(service.getGuild(guild.name).toList()).isEmpty()
-            }
-
-            @Test
-            fun `when another guild is added`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString(), Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                val guild2 =
-                    Guild(1, getRandomString(), getRandomString(), Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                service.importGuild(guild)
-                service.importGuild(guild2)
-
-                assertThat(service.getGuild(guild.name).toList()).containsExactly(guild)
-                assertThat(service.getGuild(guild2.name).toList()).containsExactly(guild2)
-            }
-
         }
 
-        @Nested
-        inner class WithCacheGuild {
-
-            @Test
-            fun `when guild is not deleted`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
-                assertThat(service.getGuild(guild.name).toList()).containsExactly(guild)
+        @Test
+        fun `when guild is deleted`() = runTest {
+            withGuildImportedAndCreated {
+                service.deleteGuild(it.id)
+                assertThat(service.getGuild(it.name).toList()).isEmpty()
             }
+        }
 
-            @Test
-            fun `when guild is deleted`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
-                service.deleteGuild(guild.id)
-                assertThat(service.getGuild(guild.name).toList()).isEmpty()
-            }
-
-            @Test
-            fun `when another guild is added`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
+        @Test
+        fun `when another guild is added`() = runTest {
+            withGuildImportedAndCreated {
                 val guild2 = service.createGuild(getRandomString(), getRandomString())
-                assertThat(service.getGuild(guild.name).toList()).containsExactly(guild)
+                assertThat(service.getGuild(it.name).toList()).containsExactly(it)
                 assertThat(service.getGuild(guild2.name).toList()).containsExactly(guild2)
             }
-
         }
 
         @Test
@@ -642,7 +478,7 @@ class GuildCacheServiceTest {
 
         @Test
         fun `with lot of guilds`() = runTest {
-            val numberOfGuilds = 1000
+            val numberOfGuilds = 200
             val name = getRandomString()
             val createdGuild = List(numberOfGuilds) {
                 service.createGuild(
@@ -655,8 +491,7 @@ class GuildCacheServiceTest {
                 Guild(
                     it,
                     name = if (it < numberOfGuilds / 2) name else getRandomString(),
-                    getRandomString(),
-                    Instant.now().truncatedTo(ChronoUnit.MILLIS)
+                    getRandomString()
                 ).apply {
                     service.importGuild(this)
                 }
@@ -670,76 +505,33 @@ class GuildCacheServiceTest {
     @Nested
     inner class IsOwner {
 
-        @Nested
-        inner class WithImportedGuild {
-
-            @Test
-            fun `when owner of guild`() = runTest {
-                val owner = getRandomString()
-                val guild = Guild(0, getRandomString(), owner, Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                service.importGuild(guild)
-                assertTrue { service.isOwner(guild.id, owner) }
-            }
-
-            @Test
-            fun `when owner of several guilds`() = runTest {
-                val owner = getRandomString()
-                val guild = Guild(0, getRandomString(), owner, Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                val guild2 = Guild(1, getRandomString(), owner, Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                service.importGuild(guild)
-                service.importGuild(guild2)
-                assertTrue { service.isOwner(guild.id, owner) }
-                assertTrue { service.isOwner(guild2.id, owner) }
-            }
-
-            @Test
-            fun `when not owner of guild`() = runTest {
-                val owner = getRandomString()
-                val guild = Guild(0, getRandomString(), owner, Instant.now().truncatedTo(ChronoUnit.MILLIS))
-                service.importGuild(guild)
-                assertFalse { service.isOwner(guild.id, getRandomString()) }
-            }
-
-            @Test
-            fun `when guild does not exist`() = runTest {
-                assertFalse { service.isOwner(0, getRandomString()) }
+        @Test
+        fun `when owner of guild`() = runTest {
+            withGuildImportedAndCreated {
+                assertTrue { service.isOwner(it.id, it.ownerId) }
             }
         }
 
-        @Nested
-        inner class WithCacheGuild {
-
-            @Test
-            fun `when owner of guild`() = runTest {
-                val owner = getRandomString()
-                val guild = service.createGuild(getRandomString(), owner)
-                assertTrue { service.isOwner(guild.id, owner) }
+        @Test
+        fun `when owner of several guilds`() = runTest {
+            withGuildImportedAndCreated {
+                val ownerId = it.ownerId
+                val guild2 = service.createGuild(getRandomString(), ownerId)
+                assertTrue { service.isOwner(it.id, ownerId) }
+                assertTrue { service.isOwner(guild2.id, ownerId) }
             }
+        }
 
-            @Test
-            fun `when owner of several guilds`() = runTest {
-                val owner = getRandomString()
-                val guild = service.createGuild(getRandomString(), owner)
-                val guild2 = service.createGuild(getRandomString(), owner)
-                assertTrue { service.isOwner(guild.id, owner) }
-                assertTrue { service.isOwner(guild2.id, owner) }
+        @Test
+        fun `when not owner of guild`() = runTest {
+            withGuildImportedAndCreated {
+                assertFalse { service.isOwner(it.id, getRandomString()) }
             }
+        }
 
-            @Test
-            fun `when not owner of guild`() = runTest {
-                val owner = getRandomString()
-                val guild = service.createGuild(getRandomString(), owner)
-                assertFalse { service.isOwner(guild.id, getRandomString()) }
-            }
-
-            @Test
-            fun `when guild does not exist`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
-
-                assertFalse { service.isOwner(guild.id, getRandomString()) }
-                assertFalse { service.isOwner(0, getRandomString()) }
-            }
-
+        @Test
+        fun `when guild does not exist`() = runTest {
+            assertFalse { service.isOwner(0, getRandomString()) }
         }
 
         @ParameterizedTest
@@ -755,128 +547,62 @@ class GuildCacheServiceTest {
     @Nested
     inner class IsMember {
 
-        @Nested
-        inner class WithImportedGuild {
-
-            @Test
-            fun `when entity is a member of the guild`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
-
+        @Test
+        fun `when entity is a member of the guild`() = runTest {
+            withGuildImportedAndCreated {
                 val entityId = getRandomString()
-                service.addMember(guild.id, entityId)
-                assertTrue { service.isMember(guild.id, entityId) }
+                service.addMember(it.id, entityId)
+                assertTrue { service.isMember(it.id, entityId) }
             }
-
-            @Test
-            fun `when entity is not a member of the guild`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
-                val entityId = getRandomString()
-                assertFalse { service.isMember(guild.id, entityId) }
-            }
-
-            @Test
-            fun `when entity is invited in the guild`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
-                val entityId = getRandomString()
-                service.addInvitation(guild.id, entityId, null)
-                assertFalse { service.isMember(guild.id, entityId) }
-            }
-
-            @Test
-            fun `when entity is member of another guild`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
-                val guild2 = Guild(1, getRandomString(), getRandomString())
-                service.importGuild(guild2)
-                val entityId = getRandomString()
-                service.addMember(guild.id, entityId)
-
-                assertFalse { service.isMember(guild2.id, entityId) }
-            }
-
-            @Test
-            fun `when another entity is member of the guild`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
-
-                val entityId = getRandomString()
-                val entity2Id = getRandomString()
-                service.addMember(guild.id, entity2Id)
-                assertFalse { service.isMember(guild.id, entityId) }
-            }
-
-            @Test
-            fun `when entity is removed of members`() = runTest {
-                val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
-
-                val entityId = getRandomString()
-                service.addMember(guild.id, entityId)
-                assertTrue { service.isMember(guild.id, entityId) }
-
-                service.removeMember(guild.id, entityId)
-                assertFalse { service.isMember(guild.id, entityId) }
-            }
-
         }
 
-        @Nested
-        inner class WithCacheGuild {
-
-            @Test
-            fun `when entity is a member of the guild`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
+        @Test
+        fun `when entity is not a member of the guild`() = runTest {
+            withGuildImportedAndCreated {
                 val entityId = getRandomString()
-                service.addMember(guild.id, entityId)
-                assertTrue { service.isMember(guild.id, entityId) }
+                assertFalse { service.isMember(it.id, entityId) }
             }
+        }
 
-            @Test
-            fun `when entity is not a member of the guild`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
+        @Test
+        fun `when entity is invited in the guild`() = runTest {
+            withGuildImportedAndCreated {
                 val entityId = getRandomString()
-                assertFalse { service.isMember(guild.id, entityId) }
+                service.addInvitation(it.id, entityId, null)
+                assertFalse { service.isMember(it.id, entityId) }
             }
+        }
 
-            @Test
-            fun `when entity is invited in the guild`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
-                val entityId = getRandomString()
-                service.addInvitation(guild.id, entityId, null)
-                assertFalse { service.isMember(guild.id, entityId) }
-            }
-
-            @Test
-            fun `when entity is member of another guild`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
+        @Test
+        fun `when entity is member of another guild`() = runTest {
+            withGuildImportedAndCreated {
                 val guild2 = service.createGuild(getRandomString(), getRandomString())
                 val entityId = getRandomString()
-                service.addMember(guild.id, entityId)
+                service.addMember(it.id, entityId)
                 assertFalse { service.isMember(guild2.id, entityId) }
             }
+        }
 
-            @Test
-            fun `when another entity is member of the guild`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
+        @Test
+        fun `when another entity is member of the guild`() = runTest {
+            withGuildImportedAndCreated {
                 val entityId = getRandomString()
                 val entity2Id = getRandomString()
-                service.addMember(guild.id, entity2Id)
-                assertFalse { service.isMember(guild.id, entityId) }
+                service.addMember(it.id, entity2Id)
+                assertFalse { service.isMember(it.id, entityId) }
             }
+        }
 
-            @Test
-            fun `when entity is removed of members`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
+        @Test
+        fun `when entity is removed of members`() = runTest {
+            withGuildImportedAndCreated {
                 val entityId = getRandomString()
-                service.addMember(guild.id, entityId)
-                assertTrue { service.isMember(guild.id, entityId) }
-                service.removeMember(guild.id, entityId)
-                assertFalse { service.isMember(guild.id, entityId) }
-            }
+                service.addMember(it.id, entityId)
+                assertTrue { service.isMember(it.id, entityId) }
 
+                service.removeMember(it.id, entityId)
+                assertFalse { service.isMember(it.id, entityId) }
+            }
         }
 
         @ParameterizedTest
@@ -902,41 +628,45 @@ class GuildCacheServiceTest {
 
             @Test
             fun `with field`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
-                val entityId = getRandomString()
-                val now = Instant.now()
-                val expirationDate = now.plusSeconds(10)
-                assertTrue { service.addInvitation(guild.id, entityId, expirationDate) }
+                withGuildImportedAndCreated {
+                    val guildId = it.id
+                    val entityId = getRandomString()
+                    val now = Instant.now()
+                    val expirationDate = now.plusSeconds(10)
+                    assertTrue { service.addInvitation(guildId, entityId, expirationDate) }
 
-                val guildIdString = guild.id.toString()
-                assertThat(getAllInvites(guildIdString)).isEmpty()
-                assertThat(getAllAddInvites(guildIdString)).hasSize(1)
-                assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
-                val inviteForGuild = getAllAddInvites(guild.id.toString())
+                    val guildIdString = guildId.toString()
+                    assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+                    assertThat(getAllAddedInvites(guildIdString)).hasSize(1)
+                    assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                    val inviteForGuild = getAllAddedInvites(guildIdString)
 
-                val invite = inviteForGuild.single()
-                assertEquals(entityId, invite.entityId)
-                assertEquals(
-                    expirationDate.truncatedTo(ChronoUnit.SECONDS),
-                    invite.expiredAt!!.truncatedTo(ChronoUnit.SECONDS)
-                )
+                    val invite = inviteForGuild.single()
+                    assertEquals(entityId, invite.entityId)
+                    assertEquals(
+                        expirationDate.truncatedTo(ChronoUnit.SECONDS),
+                        invite.expiredAt!!.truncatedTo(ChronoUnit.SECONDS)
+                    )
+                }
             }
 
             @Test
             fun `without field`() = runTest {
-                val guild = service.createGuild(getRandomString(), getRandomString())
-                val entityId = getRandomString()
-                assertTrue { service.addInvitation(guild.id, entityId, null) }
+                withGuildImportedAndCreated {
+                    val guildId = it.id
+                    val entityId = getRandomString()
+                    assertTrue { service.addInvitation(guildId, entityId, null) }
 
-                val guildIdString = guild.id.toString()
-                assertThat(getAllInvites(guildIdString)).isEmpty()
-                assertThat(getAllAddInvites(guildIdString)).hasSize(1)
-                assertThat(getAllRemoveInvites(guildIdString)).isEmpty()
-                val inviteForGuild = getAllAddInvites(guild.id.toString())
+                    val guildIdString = guildId.toString()
+                    assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+                    assertThat(getAllAddedInvites(guildIdString)).hasSize(1)
+                    assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                    val inviteForGuild = getAllAddedInvites(guildIdString)
 
-                val invite = inviteForGuild.single()
-                assertEquals(entityId, invite.entityId)
-                assertNull(invite.expiredAt)
+                    val invite = inviteForGuild.single()
+                    assertEquals(entityId, invite.entityId)
+                    assertNull(invite.expiredAt)
+                }
             }
 
             @Test
@@ -953,65 +683,91 @@ class GuildCacheServiceTest {
 
         @Test
         fun `when entity is not invited in a guild`() = runTest {
-            val guild = service.createGuild(getRandomString(), getRandomString())
-            val entityId = getRandomString()
-            assertTrue { service.addInvitation(guild.id, entityId, null) }
+            withGuildImportedAndCreated {
+                val guildId = it.id
+                val entityId = getRandomString()
+                assertTrue { service.addInvitation(guildId, entityId, null) }
 
-            val invited = service.getInvited(guild.id).toList()
-            assertContentEquals(listOf(entityId), invited)
+                val invitations = service.getInvitations(guildId).toList()
+                assertThat(invitations).containsExactly(
+                    GuildInvite(guildId, entityId, null)
+                )
+            }
         }
 
         @Test
         fun `when entity is already a member of the guild`() = runTest {
-            val guild = service.createGuild(getRandomString(), getRandomString())
-            val entityId = getRandomString()
-            assertTrue { service.addMember(guild.id, entityId) }
-            assertTrue { service.addInvitation(guild.id, entityId, null) }
+            withGuildImportedAndCreated {
+                val guildId = it.id
+                val entityId = getRandomString()
+                assertTrue { service.addMember(guildId, entityId) }
+                assertThrows<GuildInvitedIsAlreadyMemberException> {
+                    service.addInvitation(guildId, entityId, null)
+                }
 
-            assertThat(getAllAddInvites(guild.id.toString())).containsExactly(
-                GuildInvite(guild.id, entityId, null)
-            )
+                assertThat(getAllAddedInvites(guildId.toString())).isEmpty()
+            }
         }
 
         @Test
         fun `when entity is invited in another guild`() = runTest {
-            val guild = service.createGuild(getRandomString(), getRandomString())
-            val guild2 = service.createGuild(getRandomString(), getRandomString())
+            withGuildImportedAndCreated {
+                val guildId = it.id
+                val guild2 = service.createGuild(getRandomString(), getRandomString())
+                val guildId2 = guild2.id
 
-            val entityId = getRandomString()
-            assertTrue { service.addInvitation(guild.id, entityId, null) }
-            assertTrue { service.addInvitation(guild2.id, entityId, null) }
+                val entityId = getRandomString()
+                assertTrue { service.addInvitation(guildId, entityId, null) }
+                assertTrue { service.addInvitation(guildId2, entityId, null) }
 
-            assertEquals(entityId, service.getInvited(guild.id).toList().single())
-            assertEquals(entityId, service.getInvited(guild2.id).toList().single())
+                assertThat(service.getInvitations(guildId).toList()).containsExactly(
+                    GuildInvite(guildId, entityId, null)
+                )
+                assertThat(service.getInvitations(guild2.id).toList()).containsExactly(
+                    GuildInvite(guildId2, entityId, null)
+                )
+            }
         }
 
         @Test
         fun `when entity is owner of a guild`() = runTest {
-            val guild = service.createGuild(getRandomString(), getRandomString())
-            assertTrue { service.addInvitation(guild.id, guild.ownerId, null) }
-
-            val invited = service.getInvited(guild.id).toList()
-            assertThat(getAllAddInvites(guild.id.toString())).containsExactly(
-                GuildInvite(guild.id, guild.ownerId, null)
-            )
+            withGuildImportedAndCreated {
+                assertThrows<GuildInvitedIsAlreadyMemberException> {
+                    service.addInvitation(it.id, it.ownerId, null)
+                }
+                assertThat(getAllAddedInvites(it.id.toString())).isEmpty()
+            }
         }
 
         @Test
         fun `when entity is already invited`() = runTest {
-            val guild = service.createGuild(getRandomString(), getRandomString())
-            val entityId = getRandomString()
-            val expiredAt = Instant.now().plusSeconds(10)
-            assertTrue { service.addInvitation(guild.id, entityId, null) }
-            assertFalse { service.addInvitation(guild.id, entityId, null) }
-            assertTrue { service.addInvitation(guild.id, entityId, expiredAt) }
+            withGuildImportedAndCreated {
+                val guildId = it.id
+                val entityId = getRandomString()
+                val expiredAt = Instant.now().plusSeconds(10).truncatedTo(ChronoUnit.SECONDS)
+                assertTrue { service.addInvitation(guildId, entityId, null) }
+                assertFalse { service.addInvitation(guildId, entityId, null) }
+                assertTrue { service.addInvitation(guildId, entityId, expiredAt) }
 
-            val invited = service.getInvited(guild.id).toList()
-            assertContentEquals(listOf(entityId), invited)
+                assertThat(getAllAddedInvites(guildId.toString())).containsExactly(
+                    GuildInvite(guildId, entityId, expiredAt)
+                )
+            }
+        }
 
-            assertThat(getAllAddInvites(guild.id.toString())).containsExactly(
-                GuildInvite(guild.id, entityId, expiredAt)
-            )
+        @Test
+        fun `when entity is already invited by an imported invitation`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+
+            val invite = GuildInvite(guildId, getRandomString(), null)
+            service.importInvitations(listOf(invite))
+
+            assertFalse { service.addInvitation(invite.guildId, invite.entityId, invite.expiredAt) }
+            assertThat(getAllAddedInvites(guildId.toString())).isEmpty()
+            assertThat(getAllImportedInvites(guildId.toString())).containsExactly(invite)
+            assertThat(getAllRemovedInvites(guildId.toString())).isEmpty()
         }
 
         @ParameterizedTest
@@ -1031,14 +787,401 @@ class GuildCacheServiceTest {
         }
     }
 
+    @Nested
+    inner class RemoveInvitation {
+
+        @Nested
+        inner class WithAddedInvitation {
+
+            @Test
+            fun `when entity is invited in the guild`() = runTest {
+                withGuildImportedAndCreated {
+                    val guildId = it.id
+                    val guildIdString = guildId.toString()
+                    val entityId = getRandomString()
+                    service.addInvitation(guildId, entityId, null)
+
+                    assertThat(getAllAddedInvites(guildIdString)).containsExactly(
+                        GuildInvite(guildId, entityId, null)
+                    )
+
+                    assertTrue { service.removeInvitation(guildId, entityId) }
+
+                    assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+                    assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                    assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+                }
+            }
+
+            @Test
+            fun `when another entity is invited in the guild`() = runTest {
+                withGuildImportedAndCreated {
+                    val guildId = it.id
+                    val guildIdString = guildId.toString()
+                    val entityId = getRandomString()
+                    val entityId2 = getRandomString()
+
+                    service.addInvitation(guildId, entityId, null)
+                    assertFalse { service.removeInvitation(guildId, entityId2) }
+
+                    assertThat(getAllAddedInvites(guildIdString)).containsExactly(
+                        GuildInvite(guildId, entityId, null)
+                    )
+                    assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                    assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+                }
+            }
+
+        }
+
+        @Nested
+        inner class WithImportedInvitation {
+
+            @Test
+            fun `when entity is invited in the guild`() = runTest {
+                val guild = Guild(0, getRandomString(), getRandomString())
+                service.importGuild(guild)
+
+                val guildId = guild.id
+                val guildIdString = guildId.toString()
+                val entityId = getRandomString()
+
+                val expectedInvite = GuildInvite(guildId, entityId, null)
+                service.importInvitations(listOf(expectedInvite))
+
+                assertThat(getAllImportedInvites(guildIdString)).containsExactly(
+                    expectedInvite
+                )
+
+                assertTrue { service.removeInvitation(guildId, entityId) }
+
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+                assertThat(getAllRemovedInvites(guildIdString)).containsExactly(
+                    expectedInvite.entityId
+                )
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+            }
+
+            @Test
+            fun `when another entity is invited in the guild`() = runTest {
+                val guild = Guild(0, getRandomString(), getRandomString())
+                service.importGuild(guild)
+
+                val guildId = guild.id
+                val guildIdString = guildId.toString()
+                val entityId = getRandomString()
+                val entityId2 = getRandomString()
+
+                val expectedInvite = GuildInvite(guildId, entityId, null)
+                service.importInvitations(listOf(expectedInvite))
+
+                assertFalse { service.removeInvitation(guildId, entityId2) }
+
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+                assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+                assertThat(getAllImportedInvites(guildIdString)).containsExactly(expectedInvite)
+            }
+
+        }
+
+        @Test
+        fun `when entity is not invited in the guild`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val guildIdString = guildId.toString()
+            val entityId = getRandomString()
+            assertFalse { service.removeInvitation(guildId, entityId) }
+
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+            assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+        }
+
+        @Test
+        fun `when guild does not exist`() = runTest {
+            assertFalse { service.removeInvitation(0, getRandomString()) }
+        }
+
+        @Test
+        fun `when entity is owner of the guild`() = runTest {
+            withGuildImportedAndCreated {
+                assertFalse { service.removeInvitation(it.id, it.ownerId) }
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["", " ", "  ", "   "])
+        fun `when entity id is blank`(id: String) = runTest {
+            assertThrows<IllegalArgumentException> {
+                service.removeInvitation(0, id)
+            }
+        }
+    }
+
+    @Nested
+    inner class GetInvitations {
+
+        @Test
+        fun `when guild has no invitations`() = runTest {
+            withGuildImportedAndCreated {
+                val invitations = service.getInvitations(it.id).toList()
+                assertThat(invitations).isEmpty()
+            }
+        }
+
+        @Test
+        fun `when an entity is member but not invited`() = runTest {
+            withGuildImportedAndCreated {
+                val guild = service.createGuild(getRandomString(), it.ownerId)
+                service.addMember(guild.id, getRandomString())
+                service.importMembers(guild.id, listOf(getRandomString()))
+
+                val invitations = service.getInvitations(guild.id).toList()
+                assertThat(invitations).isEmpty()
+            }
+        }
+
+        @Test
+        fun `when guild does not exist`() = runTest {
+            val members = service.getInvitations(0).toList()
+            assertContentEquals(emptyList(), members)
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [1, 2, 3, 4, 5])
+        fun `with added invitation`(number: Int) = runTest {
+            withGuildImportedAndCreated {
+                val guildId = it.id
+                val invites = List(number) { GuildInvite(guildId, getRandomString(), null) }.onEach { invite ->
+                    service.addInvitation(guildId, invite.entityId, null)
+                }
+
+                val invitations = service.getInvitations(guildId).toList()
+                assertThat(invitations).containsExactlyInAnyOrderElementsOf(invites)
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [1, 2, 3, 4, 5])
+        fun `with added invitation that are deleted`(number: Int) = runTest {
+            withGuildImportedAndCreated {
+                val guildId = it.id
+                val invitesAdded = List(number) { GuildInvite(guildId, getRandomString(), null) }.onEach { invite ->
+                    service.addInvitation(guildId, invite.entityId, null)
+                }
+
+                invitesAdded.forEach { invite ->
+                    service.removeInvitation(guildId, invite.entityId)
+                }
+
+                val invitationsAfterRemoval = service.getInvitations(guildId).toList()
+                assertThat(invitationsAfterRemoval).isEmpty()
+            }
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [1, 2, 3, 4, 5])
+        fun `with imported invitation`(number: Int) = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val expectedInvites = List(number) { GuildInvite(guildId, getRandomString(), null) }
+            service.importInvitations(expectedInvites)
+
+            val invites = service.getInvitations(guildId).toList()
+            assertThat(invites).containsExactlyInAnyOrderElementsOf(expectedInvites)
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [1, 2, 3, 4, 5])
+        fun `with imported invitation that are deleted`(number: Int) = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val invites = List(number) { GuildInvite(guildId, getRandomString(), null) }
+            service.importInvitations(invites)
+
+            invites.forEach { invite ->
+                service.removeInvitation(guildId, invite.entityId)
+            }
+
+            val invitationsAfterRemoval = service.getInvitations(guildId).toList()
+            assertThat(invitationsAfterRemoval).isEmpty()
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [1, 2, 3, 4, 5])
+        fun `with imported and added invitation`(number: Int) = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+
+            val importedInvites = List(number) { GuildInvite(guildId, getRandomString(), null) }
+            service.importInvitations(importedInvites)
+
+            val addedInvites = List(number) { GuildInvite(guildId, getRandomString(), null) }.onEach { invite ->
+                service.addInvitation(guildId, invite.entityId, null)
+            }
+
+            val invites = service.getInvitations(guildId).toList()
+            assertThat(invites).containsExactlyInAnyOrderElementsOf(importedInvites + addedInvites)
+        }
+    }
+
+    @Nested
+    inner class ImportInvitations {
+
+        @Test
+        fun `with empty list`() = runTest {
+            assertFalse { service.importInvitations(emptyList()) }
+        }
+
+        @Test
+        fun `with one invitation with a non existing guild`() = runTest {
+            val invites = listOf(GuildInvite(0, getRandomString(), null))
+            assertThrows<GuildNotFoundException> {
+                service.importInvitations(invites)
+            }
+        }
+
+        @Test
+        fun `should throw exception if at least one guild is not found`() = runTest {
+            withGuildImportedAndCreated {
+                val guildId = it.id
+                val invites = listOf(
+                    GuildInvite(guildId, getRandomString(), null),
+                    GuildInvite(guildId + 1, getRandomString(), null)
+                )
+                assertThrows<GuildNotFoundException> {
+                    service.importInvitations(invites)
+                }
+
+                val guildIdString = guildId.toString()
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+
+                val guildIdString2 = (guildId + 1).toString()
+                assertThat(getAllImportedInvites(guildIdString2)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString2)).isEmpty()
+            }
+        }
+
+        @Test
+        fun `should throw exception if at least one invitation is expired`() = runTest {
+            withGuildImportedAndCreated {
+                val guildId = it.id
+                val invites = listOf(
+                    GuildInvite(guildId, getRandomString(), null),
+                    GuildInvite(guildId, getRandomString(), Instant.now().minusSeconds(1))
+                )
+
+                assertThrows<IllegalArgumentException> {
+                    service.importInvitations(invites)
+                }
+
+                val guildIdString = guildId.toString()
+                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+            }
+        }
+
+        @Test
+        fun `should filter out invitation marked as deleted`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val guildIdString = guildId.toString()
+
+            val invites = List(5) { GuildInvite(guildId, getRandomString(), null) }
+            assertTrue { service.importInvitations(invites) }
+            assertThat(getAllImportedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invites)
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+            assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+
+            val invitesToDelete = invites.take(3)
+            val invitesEntitiesDeleted = invitesToDelete.map { it.entityId }
+            val invitesToKeep = invites.drop(3)
+
+            invitesToDelete.forEach { invite ->
+                service.removeInvitation(guildId, invite.entityId)
+            }
+            assertThat(getAllRemovedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invitesEntitiesDeleted)
+            assertThat(getAllImportedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invitesToKeep)
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+
+            val inviteShouldBeImported = GuildInvite(guildId, getRandomString(), null)
+            val newInvites = invitesToDelete + inviteShouldBeImported
+            assertTrue { service.importInvitations(newInvites) }
+            assertThat(getAllImportedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invitesToKeep + inviteShouldBeImported)
+            assertThat(getAllRemovedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invitesEntitiesDeleted)
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+        }
+
+        @Test
+        fun `should return false when all imported invitations are marked as deleted`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val guildIdString = guildId.toString()
+
+            val invites = List(5) { GuildInvite(guildId, getRandomString(), null) }
+            assertTrue { service.importInvitations(invites) }
+            assertThat(getAllImportedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invites)
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+            assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
+
+            invites.forEach { invite ->
+                service.removeInvitation(guildId, invite.entityId)
+            }
+            val invitesEntitiesDeleted = invites.map { it.entityId }
+            assertThat(getAllRemovedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invitesEntitiesDeleted)
+            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+
+            assertFalse { service.importInvitations(invites) }
+            assertThat(getAllRemovedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invitesEntitiesDeleted)
+            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+        }
+
+        @Test
+        fun `should set as imported the added invitations`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val guildIdString = guildId.toString()
+
+            val invites = List(5) { GuildInvite(guildId, getRandomString(), null) }
+            val invitesToAdd = invites.take(3)
+            val invitesToImport = invites.drop(3)
+
+            invitesToAdd.forEach { invite ->
+                assertTrue { service.addInvitation(invite.guildId, invite.entityId, invite.expiredAt) }
+            }
+            assertTrue { service.importInvitations(invitesToImport) }
+
+            assertThat(getAllImportedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invitesToImport)
+            assertThat(getAllAddedInvites(guildIdString)).containsOnlyOnceElementsOf(invitesToAdd)
+
+            assertTrue { service.importInvitations(invitesToAdd) }
+            assertThat(getAllImportedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invites)
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+        }
+    }
+
     private suspend fun getAllImportedGuilds(): List<Guild> {
-        return getAllDataFromKey(GuildCacheService.Type.IMPORT_GUILD).map { keyValue ->
+        return getAllDataFromKey(GuildCacheService.Type.IMPORT_GUILD, "*").filter {
+            it.key.decodeToString().endsWith(GuildCacheService.Type.IMPORT_GUILD.key)
+        }.map { keyValue ->
             cacheClient.binaryFormat.decodeFromByteArray(Guild.serializer(), keyValue.value)
         }
     }
 
     private suspend fun getAllAddedGuilds(): List<Guild> {
-        return getAllDataFromKey(GuildCacheService.Type.ADD_GUILD).map { keyValue ->
+        return getAllDataFromKey(GuildCacheService.Type.ADD_GUILD, "*").filter {
+            it.key.decodeToString().endsWith(GuildCacheService.Type.ADD_GUILD.key)
+        }.map { keyValue ->
             cacheClient.binaryFormat.decodeFromByteArray(Guild.serializer(), keyValue.value)
         }
     }
@@ -1046,59 +1189,46 @@ class GuildCacheServiceTest {
     private suspend fun getAllDeletedGuilds(): List<Int> {
         val key = (service.prefixCommonKey + GuildCacheService.Type.REMOVE_GUILD.key).encodeToByteArray()
         return cacheClient.connect {
-            it.smembers(key).map {
-                cacheClient.binaryFormat.decodeFromByteArray(Int.serializer(), it)
+            it.smembers(key).map { value ->
+                cacheClient.binaryFormat.decodeFromByteArray(Int.serializer(), value)
             }.toList()
         }
     }
 
-    private suspend fun keyExists(type: GuildCacheService.Type, guildId: String): Boolean {
-        val key = service.prefixKey.format(guildId) + type.key
-        return keyExists(key)
+    private suspend fun getAllImportedInvites(guildId: String): List<GuildInvite> {
+        return getAllInvitesWithReplacement(GuildCacheService.Type.IMPORT_INVITATION, guildId)
     }
 
-    private suspend fun commonKeyExists(type: GuildCacheService.Type): Boolean {
-        val key = service.prefixCommonKey + type.key
-        return keyExists(key)
+    private suspend fun getAllAddedInvites(guildId: String): List<GuildInvite> {
+        return getAllInvitesWithReplacement(GuildCacheService.Type.ADD_INVITATION, guildId)
     }
 
-    private suspend fun keyExists(key: String): Boolean {
-        return cacheClient.connect {
-            it.exists(key.encodeToByteArray())
-        } == 1L
+    private suspend fun getAllInvitesWithReplacement(type: GuildCacheService.Type, guildId: String): List<GuildInvite> {
+        return getAllDataFromKey(type, guildId, "*")
+            .map { keyValue ->
+                cacheClient.binaryFormat.decodeFromByteArray(GuildInvite.serializer(), keyValue.value)
+            }
     }
 
-    private suspend fun getAllInvites(guildId: String): List<GuildInvite> {
-        return getAllValuesOfSet(GuildCacheService.Type.IMPORT_INVITATION, guildId).map {
-            cacheClient.binaryFormat.decodeFromByteArray(GuildInvite.serializer(), it)
-        }
-    }
-
-    private suspend fun getAllAddInvites(guildId: String): List<GuildInvite> {
-        return getAllValuesOfSet(GuildCacheService.Type.ADD_INVITATION, guildId).map {
-            cacheClient.binaryFormat.decodeFromByteArray(GuildInvite.serializer(), it)
-        }
-    }
-
-    private suspend fun getAllRemoveInvites(guildId: String): List<String> {
+    private suspend fun getAllRemovedInvites(guildId: String): List<String> {
         return getAllValuesOfSet(GuildCacheService.Type.REMOVE_INVITATION, guildId).map {
             cacheClient.binaryFormat.decodeFromByteArray(String.serializer(), it)
         }
     }
 
-    private suspend fun getAllMembers(guildId: String): List<String> {
+    private suspend fun getAllImportedMembers(guildId: String): List<String> {
         return getAllValuesOfSet(GuildCacheService.Type.IMPORT_MEMBER, guildId).map {
             cacheClient.binaryFormat.decodeFromByteArray(String.serializer(), it)
         }
     }
 
-    private suspend fun getAllAddMembers(guildId: String): List<String> {
+    private suspend fun getAllAddedMembers(guildId: String): List<String> {
         return getAllValuesOfSet(GuildCacheService.Type.ADD_MEMBER, guildId).map {
             cacheClient.binaryFormat.decodeFromByteArray(String.serializer(), it)
         }
     }
 
-    private suspend fun getAllRemoveMembers(guildId: String): List<String> {
+    private suspend fun getAllRemovedMembers(guildId: String): List<String> {
         return getAllValuesOfSet(GuildCacheService.Type.REMOVE_MEMBER, guildId).map {
             cacheClient.binaryFormat.decodeFromByteArray(String.serializer(), it)
         }
@@ -1112,9 +1242,10 @@ class GuildCacheServiceTest {
     }
 
     private suspend fun getAllDataFromKey(
-        type: GuildCacheService.Type
+        type: GuildCacheService.Type,
+        vararg format: String
     ): List<KeyValue<ByteArray, ByteArray>> {
-        val searchKey = service.prefixKey.format("*") + type.key
+        val searchKey = (service.prefixKey + type.key).format(*format)
         return cacheClient.connect {
             val scanner = it.scan(KeyScanArgs.Builder.limit(Long.MAX_VALUE).match(searchKey))
             if (scanner == null || scanner.keys.isEmpty()) return emptyList()
@@ -1123,5 +1254,20 @@ class GuildCacheServiceTest {
                 .filter { keyValue -> keyValue.hasValue() }
                 .toList()
         }
+    }
+
+    private suspend inline fun withGuildImportedAndCreated(
+        crossinline block: suspend (Guild) -> Unit
+    ) {
+        var guild = Guild(0, getRandomString(), getRandomString())
+        service.importGuild(guild)
+        block(guild)
+
+        cacheClient.connect {
+            it.flushall(FlushMode.SYNC)
+        }
+
+        guild = service.createGuild(getRandomString(), getRandomString())
+        block(guild)
     }
 }

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildDatabaseServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildDatabaseServiceTest.kt
@@ -145,6 +145,25 @@ class GuildDatabaseServiceTest {
             assertThat(getAllGuilds()).isEmpty()
         }
 
+        @Test
+        fun `when another guild is deleted`() = runTest {
+            val guild = service.createGuild(getRandomString(), getRandomString())
+            val guild2 = service.createGuild(getRandomString(), getRandomString())
+
+            assertTrue { service.deleteGuild(guild.id) }
+            assertThat(getAllGuilds()).containsExactly(guild2)
+
+            assertTrue { service.deleteGuild(guild2.id) }
+            assertThat(getAllGuilds()).isEmpty()
+        }
+
+        @Test
+        fun `when guild is already deleted`() = runTest {
+            val guild = service.createGuild(getRandomString(), getRandomString())
+            assertTrue { service.deleteGuild(guild.id) }
+            assertFalse { service.deleteGuild(guild.id) }
+        }
+
     }
 
     @Nested
@@ -422,7 +441,7 @@ class GuildDatabaseServiceTest {
 
         @Test
         fun `when guild does not exist`() = runTest {
-            assertThrows<R2dbcDataIntegrityViolationException> {
+            assertThrows<GuildNotFoundException> {
                 service.addMember(0, getRandomString())
             }
 
@@ -638,7 +657,7 @@ class GuildDatabaseServiceTest {
 
         @Test
         fun `when guild does not exist`() = runTest {
-            assertThrows<R2dbcDataIntegrityViolationException> {
+            assertThrows<GuildNotFoundException> {
                 service.addInvitation(0, getRandomString(), null)
             }
 


### PR DESCRIPTION
# Context

Keeping consistency between the cache and the database is important.
Thus, all the rules of the database have been transcribed into the cache system