### PR TITLE
fix: Use redis map to store and store entire member information

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
@@ -249,7 +249,7 @@ public class GuildDatabaseService(public val database: R2dbcDatabase) : IGuildSe
     }
 
     override suspend fun deleteGuild(id: Int): Boolean {
-        val meta = _Guild.guild
+        val meta = guild
         val query = QueryDsl.delete(meta).where {
             meta.id eq id
         }
@@ -257,7 +257,7 @@ public class GuildDatabaseService(public val database: R2dbcDatabase) : IGuildSe
     }
 
     override suspend fun getGuild(id: Int): Guild? {
-        val meta = _Guild.guild
+        val meta = guild
         val query = QueryDsl.from(meta).where {
             meta.id eq id
         }
@@ -267,7 +267,7 @@ public class GuildDatabaseService(public val database: R2dbcDatabase) : IGuildSe
     override fun getGuild(name: String): Flow<Guild> {
         requireGuildNameNotBlank(name)
 
-        val meta = _Guild.guild
+        val meta = guild
         val query = QueryDsl.from(meta).where {
             meta.name eq name
         }
@@ -277,7 +277,7 @@ public class GuildDatabaseService(public val database: R2dbcDatabase) : IGuildSe
     override suspend fun isOwner(guildId: Int, entityId: String): Boolean {
         requireEntityIdNotBlank(entityId)
 
-        val meta = _Guild.guild
+        val meta = guild
         val query = QueryDsl.from(meta).where {
             meta.id eq guildId
             meta.ownerId eq entityId

--- a/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
@@ -16,6 +16,8 @@ import org.komapper.core.dsl.operator.literal
 import org.komapper.core.dsl.query.bind
 import org.komapper.r2dbc.R2dbcDatabase
 import java.time.Instant
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 
 /**
  * Exception about guilds information.
@@ -728,6 +730,12 @@ public class GuildCacheService(
         removeKey: (String) -> ByteArray,
         importKey: (String) -> ByteArray,
     ): Boolean {
+        contract {
+            callsInPlace(addKey, InvocationKind.AT_MOST_ONCE)
+            callsInPlace(removeKey, InvocationKind.UNKNOWN)
+            callsInPlace(importKey, InvocationKind.AT_MOST_ONCE)
+        }
+
         val guildEntities = entities.groupBy { it.guildId }
         guildEntities.keys.forEach {
             requireImportedGuild(it)
@@ -857,6 +865,11 @@ public class GuildCacheService(
         addKey: (String) -> ByteArray,
         importKey: (String) -> ByteArray
     ): Boolean {
+        contract {
+            callsInPlace(addKey, InvocationKind.AT_MOST_ONCE)
+            callsInPlace(importKey, InvocationKind.AT_MOST_ONCE)
+        }
+
         val guildId = value.guildId
         val guildIdString = guildId.toString()
         return cacheClient.connect { connection ->
@@ -920,6 +933,12 @@ public class GuildCacheService(
         removeKey: (String) -> ByteArray,
         importKey: (String) -> ByteArray
     ): Boolean {
+        contract {
+            callsInPlace(addKey, InvocationKind.AT_MOST_ONCE)
+            callsInPlace(removeKey, InvocationKind.AT_MOST_ONCE)
+            callsInPlace(importKey, InvocationKind.AT_MOST_ONCE)
+        }
+
         val guildIdString = guildId.toString()
         return cacheClient.connect { connection ->
             if (isCacheGuild(guildId)) {
@@ -961,6 +980,11 @@ public class GuildCacheService(
         addKey: (String) -> ByteArray,
         importKey: (String) -> ByteArray,
     ): Boolean {
+        contract {
+            callsInPlace(addKey, InvocationKind.AT_MOST_ONCE)
+            callsInPlace(importKey, InvocationKind.AT_MOST_ONCE)
+        }
+
         val guildIdString = guildId.toString()
 
         return cacheClient.connect { connection ->
@@ -1043,6 +1067,11 @@ public class GuildCacheService(
         addKey: (String) -> ByteArray,
         importKey: (String) -> ByteArray,
     ): Flow<ByteArray> {
+        contract {
+            callsInPlace(addKey, InvocationKind.EXACTLY_ONCE)
+            callsInPlace(importKey, InvocationKind.AT_MOST_ONCE)
+        }
+
         val guildIdString = guildId.toString()
         return if (isCacheGuild(guildId)) {
             getAllValuesOfMap(addKey(guildIdString))

--- a/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
@@ -840,7 +840,6 @@ public class GuildCacheService(
 
             guildEntities.map { (guildId, entities) ->
                 val guildIdString = guildId.toString()
-
                 val toAdd = entities.filterNot {
                     entityIsMarkedAsDeleted(connection, removeKey(guildIdString), it.entityId)
                 }
@@ -931,10 +930,10 @@ public class GuildCacheService(
             callsInPlace(importKey, InvocationKind.AT_MOST_ONCE)
         }
 
-        val guildId = value.guildId
         return cacheClient.connect { connection ->
             requirement(connection)
 
+            val guildId = value.guildId
             if (isCacheGuild(guildId)) {
                 setEntityValueIfNotEquals(connection, addKey, value, serializer)
             } else {

--- a/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
@@ -848,9 +848,7 @@ public class GuildCacheService(
 
                 bulkDeleteAddedEntities(connection, addKey(guildIdString), toAdd.map { it.entityId })
                 toAdd.forEach {
-                    val mapKey = importKey(it.guildId.toString())
-                    val encodedField = encodeKey(it.entityId)
-                    connection.hset(mapKey, encodedField, encodeToByteArray(serializer, it))
+                    setEntityValue(connection, importKey(guildIdString), it, serializer)
                 }
                 true
             }

--- a/src/main/resources/sql/guild.sql
+++ b/src/main/resources/sql/guild.sql
@@ -42,10 +42,10 @@ CREATE INDEX idx_guild_invite_expired_at ON guild_invite (expired_at);
 
 -- Create view to get guilds with members with owner
 CREATE OR REPLACE VIEW guild_members_with_owner AS
-SELECT g.id as guild_id, g.owner_id as member_id, g.created_at as created_at
+SELECT g.id as guild_id, g.owner_id as entity_id, g.created_at as created_at
 FROM guild g
 UNION ALL
-SELECT gm.guild_id as guild_id, gm.entity_id as member_id, gm.created_at as created_at
+SELECT gm.guild_id as guild_id, gm.entity_id as entity_id, gm.created_at as created_at
 FROM guild_member gm;
 
 -- Function to check if member is the owner of the guild
@@ -106,7 +106,7 @@ BEGIN
     RETURN QUERY (SELECT 1
                   FROM guild_members_with_owner g
                   WHERE g.guild_id = guild
-                    AND g.member_id = entity);
+                    AND g.entity_id = entity);
 END
 $$ LANGUAGE plpgsql;
 

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -1262,6 +1262,21 @@ class GuildCacheServiceTest {
         }
 
         @Test
+        fun `should keep integrity of invitation data`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+
+            val expiredAt = Instant.now().plusSeconds(10).truncatedTo(ChronoUnit.MILLIS)
+            val invites = listOf(GuildInvite(guildId, getRandomString(), expiredAt))
+            service.importInvitations(invites)
+
+            val guildIdString = guildId.toString()
+            val importedInvites = getAllImportedInvites(guildIdString)
+            assertThat(importedInvites).containsExactlyInAnyOrderElementsOf(invites)
+        }
+
+        @Test
         fun `with one invitation with a non existing guild`() = runTest {
             val invites = listOf(GuildInvite(0, getRandomString(), null))
             assertThrows<GuildNotFoundException> {

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -1151,6 +1151,11 @@ class GuildCacheServiceTest {
         }
 
         @Test
+        fun `should ignore empty value for entities`() = runTest {
+            TODO()
+        }
+
+        @Test
         fun `when an entity is member but not invited`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
             service.importGuild(guild)
@@ -1262,6 +1267,27 @@ class GuildCacheServiceTest {
             assertThrows<GuildNotFoundException> {
                 service.importInvitations(invites)
             }
+        }
+
+        @Test
+        fun `should throw exception if at least one invited entity is member`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val invites = listOf(
+                GuildInvite(guildId, getRandomString(), null),
+                GuildInvite(guildId, getRandomString(), null)
+            )
+
+            service.addMember(guildId, invites[0].entityId)
+
+            assertThrows<GuildInvitedIsAlreadyMemberException> {
+                service.importInvitations(invites)
+            }
+
+            val guildIdString = guildId.toString()
+            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
         }
 
         @Test

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -924,7 +924,9 @@ class GuildCacheServiceTest {
         @Test
         fun `should return false if the entity is the owner`() = runTest {
             withGuildImportedAndCreated {
-                assertFalse { service.addMember(it.id, it.ownerId) }
+                assertThrows<GuildMemberIsOwnerOfGuildException> {
+                    service.addMember(it.id, it.ownerId)
+                }
                 assertThat(getAllAddedMembers(it.id.toString())).isEmpty()
             }
         }

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -692,6 +692,13 @@ class GuildCacheServiceTest {
             }
         }
 
+        @Test
+        fun `when entity is owner of the guild`() = runTest {
+            withGuildImportedAndCreated {
+                assertTrue { service.isMember(it.id, it.ownerId) }
+            }
+        }
+
         @ParameterizedTest
         @ValueSource(ints = [-1, 0, 1])
         fun `when guild does not exist`(id: Int) = runTest {

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -837,6 +837,40 @@ class GuildCacheServiceTest {
         }
 
         @Test
+        fun `should return true when members are updated`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val guildIdString = guildId.toString()
+
+            val members = List(5) { GuildMember(guildId, getRandomString()) }
+            assertTrue { service.importMembers(members) }
+
+            assertThat(getAllImportedMembers(guildIdString)).containsExactlyInAnyOrderElementsOf(members)
+
+            val newMembers = members.map {
+                it.copy(createdAt = Instant.now().plusSeconds(1).truncatedTo(ChronoUnit.MILLIS))
+            }
+            assertTrue { service.importMembers(newMembers) }
+            assertThat(getAllImportedMembers(guildIdString)).containsExactlyInAnyOrderElementsOf(newMembers)
+            assertThat(getAllAddedMembers(guildIdString)).isEmpty()
+        }
+
+        @Test
+        fun `should return false when members are already imported with the same values`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val guildIdString = guildId.toString()
+
+            val members = List(5) { GuildMember(guildId, getRandomString()) }
+            assertTrue { service.importMembers(members) }
+            assertFalse { service.importMembers(members) }
+            assertThat(getAllImportedMembers(guildIdString)).containsExactlyInAnyOrderElementsOf(members)
+            assertThat(getAllAddedMembers(guildIdString)).isEmpty()
+        }
+
+        @Test
         fun `should import members in each targeted guild`() = runTest {
             val guild1 = Guild(0, getRandomString(), getRandomString())
             val guild2 = Guild(1, getRandomString(), getRandomString())
@@ -1073,7 +1107,7 @@ class GuildCacheServiceTest {
             assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
             assertThat(getAllImportedMembers(guildIdString)).isEmpty()
         }
-        
+
         @Test
         fun `should return false if guild doesn't exist`() = runTest {
             assertFalse { service.removeMember(0, getRandomString()) }
@@ -1732,6 +1766,40 @@ class GuildCacheServiceTest {
             assertThat(getAllAddedInvites(guildIdString)).containsOnlyOnceElementsOf(invitesToAdd)
 
             assertTrue { service.importInvitations(invitesToAdd) }
+            assertThat(getAllImportedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invites)
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+        }
+
+        @Test
+        fun `should return true when invitations are updated`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val guildIdString = guildId.toString()
+
+            val invites = List(5) { GuildInvite(guildId, getRandomString(), null) }
+            assertTrue { service.importInvitations(invites) }
+
+            assertThat(getAllImportedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invites)
+
+            val newInvites = invites.map {
+                it.copy(expiredAt = Instant.now().plusSeconds(1).truncatedTo(ChronoUnit.MILLIS))
+            }
+            assertTrue { service.importInvitations(newInvites) }
+            assertThat(getAllImportedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(newInvites)
+            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+        }
+
+        @Test
+        fun `should return false when invitations are already imported with the same values`() = runTest {
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.importGuild(guild)
+            val guildId = guild.id
+            val guildIdString = guildId.toString()
+
+            val invites = List(5) { GuildInvite(guildId, getRandomString(), null) }
+            assertTrue { service.importInvitations(invites) }
+            assertFalse { service.importInvitations(invites) }
             assertThat(getAllImportedInvites(guildIdString)).containsExactlyInAnyOrderElementsOf(invites)
             assertThat(getAllAddedInvites(guildIdString)).isEmpty()
         }

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -1544,8 +1544,10 @@ class GuildCacheServiceTest {
             service.importGuild(guild)
             val guildId = guild.id
 
-            val expiredAt = Instant.now().plusSeconds(10).truncatedTo(ChronoUnit.MILLIS)
-            val invites = listOf(GuildInvite(guildId, getRandomString(), expiredAt))
+            val now = Instant.now()
+            val expiredAt = now.plusSeconds(10).truncatedTo(ChronoUnit.MILLIS)
+            val createdAt = now.minusSeconds(10).truncatedTo(ChronoUnit.MILLIS)
+            val invites = listOf(GuildInvite(guildId, getRandomString(), expiredAt, createdAt))
             service.importInvitations(invites)
 
             val guildIdString = guildId.toString()


### PR DESCRIPTION
# Context

Currently, the member and invitation are stored in different keys. However, this produces a latency problem and complexity in maintaining the code.
In addition, when a member is added or imported, only the entity id is stored and not other information. However, it will be nice to keep all data like the database

# To do

- [x] Store entire guild member information
- [x] Use Redis map
- [x] Tests