### PR TITLE
fix: Store cache connection in coroutine context

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/core/cache/RedisConnection.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/cache/RedisConnection.kt
@@ -1,0 +1,35 @@
+package com.github.rushyverse.core.cache
+
+import io.lettuce.core.api.coroutines.RedisCoroutinesCommands
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * A coroutine element to store a Redis connection.
+ * Will be used to store the connection in the coroutine context and retrieve it later.
+ * @property connection Redis connection.
+ */
+public interface RedisConnection : CoroutineContext.Element {
+
+    public companion object Key : CoroutineContext.Key<RedisConnection>
+
+    public val connection: RedisCoroutinesCommands<ByteArray, ByteArray>
+
+}
+
+/**
+ * Implementation of [RedisConnection].
+ */
+internal class RedisConnectionImpl(override val connection: RedisCoroutinesCommands<ByteArray, ByteArray>) : RedisConnection {
+
+    override val key: CoroutineContext.Key<RedisConnection>
+        get() = RedisConnection
+
+}
+
+/**
+ * Create a coroutine element to store a Redis connection.
+ * @param connection Cache connection.
+ * @return A new instance of [RedisConnection].
+ */
+public fun RedisConnection(connection: RedisCoroutinesCommands<ByteArray, ByteArray>): RedisConnection =
+    RedisConnectionImpl(connection)


### PR DESCRIPTION
# Context

When a connection is requested, within another connection, a new connection is created instead of using the current one.

**Before**
```kt
client.connect { // connection 1
    client.connect { // connection 2

   }
}
```

**Now**
```kt
client.connect { // connection 1
    client.connect { // connection 1 (use the same connection)

   }
}
```