### PR TITLE
fix: Simplify guild management

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
@@ -999,9 +999,7 @@ public class GuildCacheService(
      * @return Flow of all invitations.
      */
     private fun getAllInvitations(): Flow<GuildInvite> =
-        getAllAddedGuilds()
-            .map { getAllInvitations(it.id) }
-            .flattenMerge()
+        getAllAddedGuilds().flatMapMerge { getAllInvitations(it.id) }
 
     /**
      * Get all invitations of a guild.

--- a/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
@@ -273,6 +273,10 @@ public interface IGuildCacheService : IGuildService {
 
 }
 
+/**
+ * Service for managing guilds in database
+ * @property database Database to use.
+ */
 public class GuildDatabaseService(public val database: R2dbcDatabase) : IGuildDatabaseService {
 
     public companion object {
@@ -576,11 +580,11 @@ public class GuildCacheService(
             }
 
             val guildId = guild.id
-            getAddedMembers(guildCacheId).safeCollect { member ->
-                supplier.addMember(guildId, member.entityId)
-            }
             getInvitations(guildCacheId).safeCollect { invitation ->
                 supplier.addInvitation(guildId, invitation.entityId, invitation.expiredAt)
+            }
+            getAddedMembers(guildCacheId).safeCollect { member ->
+                supplier.addMember(guildId, member.entityId)
             }
         }
     }

--- a/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Guild.kt
@@ -495,7 +495,6 @@ public class GuildCacheService(
         /**
          * Key to store guilds created by [GuildCacheService].
          * Is not used to store guild from other services like [GuildDatabaseService].
-         * The guilds imported from other services are stored in [IMPORT_GUILD] key.
          */
         ADD_GUILD("add"),
 
@@ -509,7 +508,6 @@ public class GuildCacheService(
         /**
          * Key to store guild's members created by [GuildCacheService].
          * Is not used to store guild's members imported from other services like [GuildDatabaseService].
-         * The guild's members imported from other services are stored in [IMPORT_MEMBER] key.
          */
         ADD_MEMBER("member:add"),
 
@@ -523,7 +521,6 @@ public class GuildCacheService(
         /**
          * Key to store guild's invitations created by [GuildCacheService].
          * Is not used to store guild's invitations imported from other services like [GuildDatabaseService].
-         * The guild's invitations imported from other services are stored in [IMPORT_INVITATION] key.
          */
         ADD_INVITATION("invite:add"),
 
@@ -640,7 +637,7 @@ public class GuildCacheService(
 
     /**
      * Check if guild exists in cache.
-     * If the guild is present in [Type.IMPORT_GUILD] or [Type.ADD_GUILD] and is not marked as deleted, it exists.
+     * If the guild is present in [Type.ADD_GUILD] and is not marked as deleted, it exists.
      * @param connection Redis connection.
      * @param id Guild ID.
      * @return `true` if guild exists, `false` otherwise.

--- a/src/main/kotlin/com/github/rushyverse/core/extension/FlowExt.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/extension/FlowExt.kt
@@ -1,0 +1,16 @@
+package com.github.rushyverse.core.extension
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Collects the given flow and runs the given action on each element.
+ * If the action throws an exception, it will be caught and ignored.
+ * @see Flow.collect
+ * @receiver Flow to collect.
+ * @param action Action to run on each element.
+ */
+public suspend fun <T> Flow<T>.safeCollect(action: suspend (T) -> Unit): Unit = collect {
+    runCatching {
+        action(it)
+    }
+}

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseFallbackEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseFallbackEntitySupplier.kt
@@ -63,6 +63,10 @@ public class DatabaseFallbackEntitySupplier(
         return getPriority.isPendingFriend(uuid, friend) || setPriority.isPendingFriend(uuid, friend)
     }
 
+    override suspend fun deleteExpiredInvitations(): Boolean {
+        return setPriority.deleteExpiredInvitations()
+    }
+
     override suspend fun createGuild(name: String, ownerId: String): Guild {
         return setPriority.createGuild(name, ownerId)
     }

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseFallbackEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseFallbackEntitySupplier.kt
@@ -63,7 +63,7 @@ public class DatabaseFallbackEntitySupplier(
         return getPriority.isPendingFriend(uuid, friend) || setPriority.isPendingFriend(uuid, friend)
     }
 
-    override suspend fun deleteExpiredInvitations(): Boolean {
+    override suspend fun deleteExpiredInvitations(): Long {
         return setPriority.deleteExpiredInvitations()
     }
 

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplier.kt
@@ -84,7 +84,7 @@ public class DatabaseStoreEntitySupplier(
 
     override suspend fun createGuild(name: String, ownerId: String): Guild {
         return supplier.createGuild(name, ownerId).also {
-            importCatchFailure(it, cache::importGuild)
+            importCatchFailure(it, cache::addGuild)
         }
     }
 
@@ -94,13 +94,13 @@ public class DatabaseStoreEntitySupplier(
 
     override suspend fun getGuild(id: Int): Guild? {
         return supplier.getGuild(id)?.also {
-            importCatchFailure(it, cache::importGuild)
+            importCatchFailure(it, cache::addGuild)
         }
     }
 
     override fun getGuild(name: String): Flow<Guild> {
         return supplier.getGuild(name).onEach {
-            importCatchFailure(it, cache::importGuild)
+            importCatchFailure(it, cache::addGuild)
         }
     }
 
@@ -150,12 +150,12 @@ public class DatabaseStoreEntitySupplier(
 
     override fun getMembers(guildId: Int): Flow<GuildMember> = supplier.getMembers(guildId)
         .onEach {
-            importCatchFailure(it, cache::importMember)
+            importCatchFailure(it, cache::addMember)
         }
 
     override fun getInvitations(guildId: Int): Flow<GuildInvite> = supplier.getInvitations(guildId)
         .onEach {
-            importCatchFailure(it, cache::importInvitation)
+            importCatchFailure(it, cache::addInvitation)
         }
 
     /**

--- a/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplier.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplier.kt
@@ -82,6 +82,10 @@ public class DatabaseStoreEntitySupplier(
         return supplier.isPendingFriend(uuid, friend)
     }
 
+    override suspend fun deleteExpiredInvitations(): Boolean {
+        return supplier.deleteExpiredInvitations().or(cache.deleteExpiredInvitations())
+    }
+
     override suspend fun createGuild(name: String, ownerId: String): Guild {
         return supplier.createGuild(name, ownerId).also {
             importCatchFailure(it, cache::addGuild)

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -83,7 +83,6 @@ class GuildCacheServiceTest {
             fun `should create and store a new guild`() = runTest {
                 val guild = service.createGuild(getRandomString(), getRandomString())
                 assertThat(getAllAddedGuilds()).containsExactly(guild)
-                assertThat(getAllImportedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).isEmpty()
             }
 
@@ -95,7 +94,6 @@ class GuildCacheServiceTest {
 
                 val guilds = getAllAddedGuilds()
                 assertThat(guilds).containsExactlyInAnyOrder(guild, guild2)
-                assertThat(getAllImportedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).isEmpty()
             }
 
@@ -109,7 +107,6 @@ class GuildCacheServiceTest {
 
                 val guilds = getAllAddedGuilds()
                 assertThat(guilds).containsExactlyInAnyOrder(guild, guild2)
-                assertThat(getAllImportedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).isEmpty()
             }
 
@@ -134,7 +131,6 @@ class GuildCacheServiceTest {
 
                 val guilds = getAllAddedGuilds()
                 assertThat(guilds).containsExactlyInAnyOrder(guild, guild2)
-                assertThat(getAllImportedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).isEmpty()
             }
 
@@ -158,7 +154,6 @@ class GuildCacheServiceTest {
 
             val addedIds: List<Int> = getAllAddedGuilds().map { it.id }
             assertThat(idsCreated).containsExactlyInAnyOrderElementsOf(addedIds)
-            assertThat(getAllImportedGuilds()).isEmpty()
             assertThat(getAllDeletedGuilds()).isEmpty()
         }
 
@@ -176,7 +171,6 @@ class GuildCacheServiceTest {
                 assertTrue { service.deleteGuild(guild.id) }
                 assertThat(getAllAddedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).isEmpty()
-                assertThat(getAllImportedGuilds()).isEmpty()
             }
 
             @Test
@@ -187,7 +181,6 @@ class GuildCacheServiceTest {
                 assertTrue { service.deleteGuild(guild.id) }
                 assertThat(getAllAddedGuilds()).containsExactlyInAnyOrder(guild2)
                 assertThat(getAllDeletedGuilds()).isEmpty()
-                assertThat(getAllImportedGuilds()).isEmpty()
             }
 
             @Test
@@ -198,7 +191,6 @@ class GuildCacheServiceTest {
 
                 assertThat(getAllAddedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).isEmpty()
-                assertThat(getAllImportedGuilds()).isEmpty()
             }
 
             @Test
@@ -220,11 +212,8 @@ class GuildCacheServiceTest {
 
                 assertTrue { service.deleteGuild(guild.id) }
 
-                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                 assertThat(getAllAddedInvites(guildIdString)).isEmpty()
-                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
                 assertThat(getAllAddedMembers(guildIdString)).isEmpty()
-                assertThat(getAllImportedGuilds()).isEmpty()
                 assertThat(getAllAddedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).isEmpty()
             }
@@ -234,7 +223,7 @@ class GuildCacheServiceTest {
                 val guild = service.createGuild(getRandomString(), getRandomString())
 
                 val guild2 = Guild(1, getRandomString(), getRandomString())
-                service.importGuild(guild2)
+                service.addGuild(guild2)
 
                 val guildId = guild2.id
                 val sizeData = 10
@@ -242,29 +231,24 @@ class GuildCacheServiceTest {
                     service.addMember(guildId, getRandomString())
                 }
                 val members = List(sizeData) { GuildMember(guildId, getRandomString()) }
-                members.forEach { service.importMember(it) }
+                members.forEach { service.addMember(it) }
 
                 repeat(sizeData) {
                     service.addInvitation(guildId, getRandomString(), null)
                 }
                 val invites = List(sizeData) { GuildInvite(guildId, getRandomString(), null) }
-                invites.forEach { service.importInvitation(it) }
+                invites.forEach { service.addInvitation(it) }
 
                 val guildIdString = guildId.toString()
 
-                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(20)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(20)
 
                 assertTrue { service.deleteGuild(guild.id) }
 
-                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllImportedGuilds()).containsExactly(guild2)
-                assertThat(getAllAddedGuilds()).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(20)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(20)
+                assertThat(getAllAddedGuilds()).containsExactly(guild2)
                 assertThat(getAllDeletedGuilds()).isEmpty()
             }
 
@@ -276,42 +260,39 @@ class GuildCacheServiceTest {
             @Test
             fun `should return true if the guild exists`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
                 assertTrue { service.deleteGuild(guild.id) }
                 assertThat(getAllAddedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
-                assertThat(getAllImportedGuilds()).isEmpty()
             }
 
             @Test
             fun `should delete only the targeted guild`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
                 val guild2 = Guild(1, getRandomString(), getRandomString())
-                service.importGuild(guild2)
+                service.addGuild(guild2)
 
                 assertTrue { service.deleteGuild(guild.id) }
-                assertThat(getAllAddedGuilds()).isEmpty()
+                assertThat(getAllAddedGuilds()).containsExactlyInAnyOrder(guild2)
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
-                assertThat(getAllImportedGuilds()).containsExactlyInAnyOrder(guild2)
             }
 
             @Test
             fun `should return false if the guild is deleted`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
                 assertTrue { service.deleteGuild(guild.id) }
                 assertFalse { service.deleteGuild(guild.id) }
 
                 assertThat(getAllAddedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
-                assertThat(getAllImportedGuilds()).isEmpty()
             }
 
             @Test
             fun `should delete all linked data to the deleted guild`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
 
                 val guildId = guild.id
                 val sizeData = 10
@@ -319,44 +300,39 @@ class GuildCacheServiceTest {
                     service.addMember(guildId, getRandomString())
                 }
                 val importedMembers = List(sizeData) { GuildMember(guildId, getRandomString()) }
-                importedMembers.forEach { service.importMember(it) }
+                importedMembers.forEach { service.addMember(it) }
 
                 val importedInvites = List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
                 }
-                importedInvites.forEach { service.importInvitation(it) }
+                importedInvites.forEach { service.addInvitation(it) }
                 repeat(sizeData) {
                     service.addInvitation(guildId, getRandomString(), null)
                 }
 
                 val guildIdString = guildId.toString()
 
-                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(20)
                 assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(20)
                 assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
 
                 assertTrue { service.deleteGuild(guild.id) }
 
-                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                 assertThat(getAllAddedInvites(guildIdString)).isEmpty()
                 assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
                 assertThat(getAllAddedMembers(guildIdString)).isEmpty()
                 assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
-                assertThat(getAllImportedGuilds()).isEmpty()
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
             }
 
             @Test
             fun `should not delete another guild data`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
 
                 val guild2 = Guild(1, getRandomString(), getRandomString())
-                service.importGuild(guild2)
+                service.addGuild(guild2)
 
                 val guildId = guild2.id
                 val sizeData = 10
@@ -364,34 +340,30 @@ class GuildCacheServiceTest {
                     service.addMember(guildId, getRandomString())
                 }
                 val importedMembers = List(sizeData) { GuildMember(guildId, getRandomString()) }
-                importedMembers.forEach { service.importMember(it) }
+                importedMembers.forEach { service.addMember(it) }
 
                 val importedInvites = List(sizeData) {
                     GuildInvite(guildId, getRandomString(), null)
                 }
-                importedInvites.forEach { service.importInvitation(it) }
+                importedInvites.forEach { service.addInvitation(it) }
                 repeat(sizeData) {
                     service.addInvitation(guildId, getRandomString(), null)
                 }
 
                 val guildIdString = guildId.toString()
 
-                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(20)
                 assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(20)
                 assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
 
                 assertTrue { service.deleteGuild(guild.id) }
 
-                assertThat(getAllImportedInvites(guildIdString)).hasSize(10)
-                assertThat(getAllAddedInvites(guildIdString)).hasSize(10)
+                assertThat(getAllAddedInvites(guildIdString)).hasSize(20)
                 assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-                assertThat(getAllImportedMembers(guildIdString)).hasSize(10)
-                assertThat(getAllAddedMembers(guildIdString)).hasSize(10)
+                assertThat(getAllAddedMembers(guildIdString)).hasSize(20)
                 assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
-                assertThat(getAllImportedGuilds()).containsExactly(guild2)
+                assertThat(getAllAddedGuilds()).containsExactly(guild2)
 
                 assertThat(getAllDeletedGuilds()).containsExactly(guild.id)
             }
@@ -403,18 +375,17 @@ class GuildCacheServiceTest {
             assertFalse { service.deleteGuild(id) }
             assertThat(getAllAddedGuilds()).isEmpty()
             assertThat(getAllDeletedGuilds()).isEmpty()
-            assertThat(getAllImportedGuilds()).isEmpty()
         }
     }
 
     @Nested
-    inner class ImportGuild {
+    inner class AddGuild {
 
         @ParameterizedTest
         @ValueSource(ints = [Int.MIN_VALUE, -800000, -1000, -1])
         fun `should throw if id is negative`(id: Int) = runTest {
             assertThrows<IllegalArgumentException> {
-                service.importGuild(Guild(id, getRandomString(), getRandomString()))
+                service.addGuild(Guild(id, getRandomString(), getRandomString()))
             }
         }
 
@@ -422,38 +393,38 @@ class GuildCacheServiceTest {
         @ValueSource(ints = [0, 1, 1000, 800000, Int.MAX_VALUE])
         fun `should import guild with positive id`(id: Int) = runTest {
             val guild = Guild(id, getRandomString(), getRandomString())
-            service.importGuild(guild)
-            assertThat(getAllImportedGuilds()).containsExactly(guild)
+            service.addGuild(guild)
+            assertThat(getAllAddedGuilds()).containsExactly(guild)
         }
 
         @Test
         fun `should replace the guild with the same id`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
 
             val guild2 = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild2)
+            service.addGuild(guild2)
 
-            assertThat(getAllImportedGuilds()).containsExactly(guild2)
+            assertThat(getAllAddedGuilds()).containsExactly(guild2)
         }
 
         @Test
-        fun `should not import if guild is deleted`() = runTest {
+        fun `should import if guild is deleted`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             service.deleteGuild(guild.id)
 
-            assertThat(getAllImportedGuilds()).isEmpty()
+            assertThat(getAllAddedGuilds()).isEmpty()
 
             val guildSameID = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guildSameID)
+            service.addGuild(guildSameID)
 
-            assertThat(getAllImportedGuilds()).isEmpty()
+            assertThat(getAllAddedGuilds()).containsExactly(guildSameID)
 
             val otherGuild = Guild(1, getRandomString(), getRandomString())
-            service.importGuild(otherGuild)
+            service.addGuild(otherGuild)
 
-            assertThat(getAllImportedGuilds()).containsExactly(otherGuild)
+            assertThat(getAllAddedGuilds()).containsExactlyInAnyOrder(guildSameID, otherGuild)
         }
     }
 
@@ -539,7 +510,7 @@ class GuildCacheServiceTest {
                     name = if (it < numberOfGuilds / 2) name else getRandomString(),
                     getRandomString()
                 ).apply {
-                    service.importGuild(this)
+                    service.addGuild(this)
                 }
             }
 
@@ -677,15 +648,15 @@ class GuildCacheServiceTest {
         @Test
         fun `should keep integrity of member data`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
 
             val createdAt = Instant.now().plusSeconds(10).truncatedTo(ChronoUnit.MILLIS)
             val member = GuildMember(guildId, getRandomString(), createdAt)
-            service.importMember(member)
+            service.addMember(member)
 
             val guildIdString = guildId.toString()
-            assertThat(getAllImportedMembers(guildIdString)).containsExactly(member)
+            assertThat(getAllAddedMembers(guildIdString)).containsExactly(member)
         }
 
         @Test
@@ -694,103 +665,77 @@ class GuildCacheServiceTest {
 
             val member = GuildMember(guildId, getRandomString())
             assertThrows<GuildNotFoundException> {
-                service.importMember(member)
+                service.addMember(member)
             }
 
-            assertThat(getAllImportedMembers(guildId.toString())).isEmpty()
             assertThat(getAllAddedMembers(guildId.toString())).isEmpty()
         }
 
         @Test
         fun `should throw exception if the owner is added as member`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val member = GuildMember(guildId, guild.ownerId)
 
             assertThrows<GuildMemberIsOwnerOfGuildException> {
-                service.importMember(member)
+                service.addMember(member)
             }
 
             val guildIdString = guildId.toString()
-            assertThat(getAllImportedMembers(guildIdString)).isEmpty()
             assertThat(getAllAddedMembers(guildIdString)).isEmpty()
         }
 
         @Test
-        fun `should return false when if member is marked as deleted`() = runTest {
+        fun `should add when if member is marked as deleted`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val guildIdString = guildId.toString()
 
             val member = GuildMember(guildId, getRandomString())
-            assertTrue { service.importMember(member) }
-            assertThat(getAllImportedMembers(guildIdString)).containsExactly(member)
-            assertThat(getAllAddedMembers(guildIdString)).isEmpty()
-
+            assertTrue { service.addMember(member) }
+            assertThat(getAllAddedMembers(guildIdString)).containsExactly(member)
             assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
 
             service.removeMember(guildId, member.entityId)
 
-            assertThat(getAllImportedMembers(guildIdString)).isEmpty()
             assertThat(getAllAddedMembers(guildIdString)).isEmpty()
             assertThat(getAllRemovedMembers(guildIdString)).containsExactly(member.entityId)
 
-            assertFalse { service.importMember(member) }
+            assertTrue { service.addMember(member) }
 
-            assertThat(getAllImportedMembers(guildIdString)).isEmpty()
-            assertThat(getAllAddedMembers(guildIdString)).isEmpty()
-            assertThat(getAllRemovedMembers(guildIdString)).containsExactly(member.entityId)
-        }
-
-        @Test
-        fun `should set as imported the added member`() = runTest {
-            val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
-            val guildId = guild.id
-            val guildIdString = guildId.toString()
-
-            val member = GuildMember(guildId, getRandomString())
-
-            assertTrue { service.addMember(guildId, member.entityId) }
-
-            assertTrue { service.importMember(member) }
-
-            assertThat(getAllImportedMembers(guildIdString)).containsExactly(member)
-            assertThat(getAllAddedMembers(guildIdString)).isEmpty()
+            assertThat(getAllAddedMembers(guildIdString)).containsExactly(member)
+            assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
         }
 
         @Test
         fun `should return true when member is updated`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val guildIdString = guildId.toString()
 
             val member = GuildMember(guildId, getRandomString())
-            assertTrue { service.importMember(member) }
-
-            assertThat(getAllImportedMembers(guildIdString)).containsExactly(member)
+            assertTrue { service.addMember(member) }
+            assertThat(getAllAddedMembers(guildIdString)).containsExactly(member)
 
             val newMembers = member.copy(createdAt = Instant.now().plusSeconds(1).truncatedTo(ChronoUnit.MILLIS))
-            assertTrue { service.importMember(newMembers) }
-            assertThat(getAllImportedMembers(guildIdString)).containsExactly(newMembers)
-            assertThat(getAllAddedMembers(guildIdString)).isEmpty()
+            assertTrue { service.addMember(newMembers) }
+            assertThat(getAllAddedMembers(guildIdString)).containsExactly(newMembers)
         }
 
         @Test
         fun `should return false when member is already imported with the same values`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val guildIdString = guildId.toString()
 
             val member = GuildMember(guildId, getRandomString())
-            assertTrue { service.importMember(member) }
-            assertFalse { service.importMember(member) }
-            assertThat(getAllImportedMembers(guildIdString)).containsExactly(member)
-            assertThat(getAllAddedMembers(guildIdString)).isEmpty()
+            assertTrue { service.addMember(member) }
+            assertFalse { service.addMember(member) }
+            assertThat(getAllAddedMembers(guildIdString)).containsExactly(member)
         }
 
         @Test
@@ -799,29 +744,27 @@ class GuildCacheServiceTest {
             val guildId = guild.id
 
             assertThrows<IllegalArgumentException> {
-                service.importMember(GuildMember(guildId, getRandomString()))
+                service.addMember(GuildMember(guildId, getRandomString()))
             }
         }
 
         @Test
         fun `should delete invitation when entity is imported as member`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val member = GuildMember(guild.id, getRandomString())
             assertTrue { service.addInvitation(member.guildId, member.entityId, null) }
-            assertTrue { service.importMember(member) }
+            assertTrue { service.addMember(member) }
 
-            assertThat(getAllImportedMembers(guild.id.toString())).containsExactly(member)
+            assertThat(getAllAddedMembers(guild.id.toString())).containsExactly(member)
             assertThat(getAllAddedInvites(guild.id.toString())).isEmpty()
-            assertThat(getAllImportedInvites(guild.id.toString())).isEmpty()
 
             val member2 = GuildMember(guild.id, getRandomString())
-            assertTrue { service.importInvitation(GuildInvite(guild.id, member2.entityId, null)) }
-            assertTrue { service.importMember(member2) }
+            assertTrue { service.addInvitation(GuildInvite(guild.id, member2.entityId, null)) }
+            assertTrue { service.addMember(member2) }
 
-            assertThat(getAllImportedMembers(guild.id.toString())).containsExactlyInAnyOrder(member, member2)
+            assertThat(getAllAddedMembers(guild.id.toString())).containsExactlyInAnyOrder(member, member2)
             assertThat(getAllAddedInvites(guild.id.toString())).isEmpty()
-            assertThat(getAllImportedInvites(guild.id.toString())).isEmpty()
         }
 
     }
@@ -849,7 +792,6 @@ class GuildCacheServiceTest {
                 assertTrue { service.addMember(guildId, entityId) }
                 assertFalse { service.addMember(guildId, entityId) }
 
-                assertThat(getAllImportedMembers(guildId.toString())).isEmpty()
                 assertThat(getAllAddedMembers(guildId.toString())).containsExactly(GuildMember(guildId, entityId))
                 assertThat(getAllRemovedMembers(guildId.toString())).isEmpty()
             }
@@ -888,15 +830,14 @@ class GuildCacheServiceTest {
         @Test
         fun `should return false if entity already member by an imported member`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
 
             val member = GuildMember(guildId, getRandomString())
-            service.importMember(member)
+            service.addMember(member)
 
             assertFalse { service.addMember(member.guildId, member.entityId) }
-            assertThat(getAllAddedMembers(guildId.toString())).isEmpty()
-            assertThat(getAllImportedMembers(guildId.toString())).containsExactly(member)
+            assertThat(getAllAddedMembers(guildId.toString())).containsExactly(member)
             assertThat(getAllRemovedMembers(guildId.toString())).isEmpty()
         }
 
@@ -914,22 +855,20 @@ class GuildCacheServiceTest {
         @Test
         fun `should delete invitation when entity is added as member for imported guild`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val member = GuildMember(guild.id, getRandomString())
             assertTrue { service.addInvitation(member.guildId, member.entityId, null) }
             assertTrue { service.addMember(member.guildId, member.entityId) }
 
             assertThat(getAllAddedMembers(guild.id.toString())).containsExactly(member)
             assertThat(getAllAddedInvites(guild.id.toString())).isEmpty()
-            assertThat(getAllImportedInvites(guild.id.toString())).isEmpty()
 
             val member2 = GuildMember(guild.id, getRandomString())
-            assertTrue { service.importInvitation(GuildInvite(guild.id, member2.entityId, null)) }
+            assertTrue { service.addInvitation(GuildInvite(guild.id, member2.entityId, null)) }
             assertTrue { service.addMember(member2.guildId, member2.entityId) }
 
             assertThat(getAllAddedMembers(guild.id.toString())).containsExactlyInAnyOrder(member, member2)
             assertThat(getAllAddedInvites(guild.id.toString())).isEmpty()
-            assertThat(getAllImportedInvites(guild.id.toString())).isEmpty()
         }
 
         @Test
@@ -943,7 +882,6 @@ class GuildCacheServiceTest {
                 assertTrue { service.addMember(guildId, member2.entityId) }
 
                 assertThat(getAllAddedMembers(guildId.toString())).containsExactlyInAnyOrder(member1, member2)
-                assertThat(getAllImportedMembers(guildId.toString())).isEmpty()
                 assertThat(getAllRemovedMembers(guildId.toString())).isEmpty()
             }
         }
@@ -987,13 +925,12 @@ class GuildCacheServiceTest {
 
                 assertThat(getAllAddedMembers(guildIdString)).isEmpty()
                 assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
-                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
             }
 
             @Test
             fun `should remove and mark as deleted if guild is imported`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
                 val guildId = guild.id
                 val guildIdString = guildId.toString()
                 val entityId = getRandomString()
@@ -1009,7 +946,6 @@ class GuildCacheServiceTest {
                 assertThat(getAllRemovedMembers(guildIdString)).containsExactly(
                     entityId
                 )
-                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
             }
 
             @Test
@@ -1027,7 +963,6 @@ class GuildCacheServiceTest {
                         GuildMember(guildId, entityId)
                     )
                     assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
-                    assertThat(getAllImportedMembers(guildIdString)).isEmpty()
                 }
             }
 
@@ -1039,16 +974,16 @@ class GuildCacheServiceTest {
             @Test
             fun `should return true if entity is member in the guild`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
 
                 val guildId = guild.id
                 val guildIdString = guildId.toString()
                 val entityId = getRandomString()
 
                 val expectedMember = GuildMember(guildId, entityId)
-                service.importMember(expectedMember)
+                service.addMember(expectedMember)
 
-                assertThat(getAllImportedMembers(guildIdString)).containsExactly(
+                assertThat(getAllAddedMembers(guildIdString)).containsExactly(
                     expectedMember
                 )
 
@@ -1058,13 +993,12 @@ class GuildCacheServiceTest {
                 assertThat(getAllRemovedMembers(guildIdString)).containsExactly(
                     expectedMember.entityId
                 )
-                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
             }
 
             @Test
             fun `should return false if another entity is member in the guild`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
 
                 val guildId = guild.id
                 val guildIdString = guildId.toString()
@@ -1072,13 +1006,12 @@ class GuildCacheServiceTest {
                 val entityId2 = getRandomString()
 
                 val expectedMember = GuildMember(guildId, entityId)
-                service.importMember(expectedMember)
+                service.addMember(expectedMember)
 
                 assertFalse { service.removeMember(guildId, entityId2) }
 
-                assertThat(getAllAddedMembers(guildIdString)).isEmpty()
+                assertThat(getAllAddedMembers(guildIdString)).containsExactly(expectedMember)
                 assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
-                assertThat(getAllImportedMembers(guildIdString)).containsExactly(expectedMember)
             }
 
         }
@@ -1086,7 +1019,7 @@ class GuildCacheServiceTest {
         @Test
         fun `should return false if entity is not member`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val guildIdString = guildId.toString()
             val entityId = getRandomString()
@@ -1094,7 +1027,6 @@ class GuildCacheServiceTest {
 
             assertThat(getAllAddedMembers(guildIdString)).isEmpty()
             assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
-            assertThat(getAllImportedMembers(guildIdString)).isEmpty()
         }
 
         @Test
@@ -1150,7 +1082,7 @@ class GuildCacheServiceTest {
         @Test
         fun `should return a flow with the owner and added or imported members`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val membersToAdd = listOf(
                 GuildMember(guild.id, getRandomString()),
                 GuildMember(guild.id, getRandomString())
@@ -1162,7 +1094,7 @@ class GuildCacheServiceTest {
             )
 
             membersToAdd.forEach { service.addMember(it.guildId, it.entityId) }
-            membersToImport.forEach { service.importMember(it) }
+            membersToImport.forEach { service.addMember(it) }
 
             val members = service.getMembers(guild.id).map(GuildMember::defaultTime).toList()
             assertThat(members).containsExactlyInAnyOrderElementsOf(
@@ -1206,7 +1138,6 @@ class GuildCacheServiceTest {
                     assertTrue { service.addInvitation(guildId, entityId, expirationDate) }
 
                     val guildIdString = guildId.toString()
-                    assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                     assertThat(getAllAddedInvites(guildIdString)).hasSize(1)
                     assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
                     val inviteForGuild = getAllAddedInvites(guildIdString)
@@ -1228,7 +1159,6 @@ class GuildCacheServiceTest {
                     assertTrue { service.addInvitation(guildId, entityId, null) }
 
                     val guildIdString = guildId.toString()
-                    assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                     assertThat(getAllAddedInvites(guildIdString)).hasSize(1)
                     assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
                     val inviteForGuild = getAllAddedInvites(guildIdString)
@@ -1328,15 +1258,14 @@ class GuildCacheServiceTest {
         @Test
         fun `should return false if entity already invited by an imported invitation`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
 
             val invite = GuildInvite(guildId, getRandomString(), null)
-            service.importInvitation(invite)
+            service.addInvitation(invite)
 
             assertFalse { service.addInvitation(invite.guildId, invite.entityId, invite.expiredAt) }
-            assertThat(getAllAddedInvites(guildId.toString())).isEmpty()
-            assertThat(getAllImportedInvites(guildId.toString())).containsExactly(invite)
+            assertThat(getAllAddedInvites(guildId.toString())).containsExactly(invite)
             assertThat(getAllRemovedInvites(guildId.toString())).isEmpty()
         }
 
@@ -1351,7 +1280,6 @@ class GuildCacheServiceTest {
                 assertTrue { service.addInvitation(invite2.guildId, invite2.entityId, invite2.expiredAt) }
 
                 assertThat(getAllAddedInvites(guildId.toString())).containsExactlyInAnyOrder(invite1, invite2)
-                assertThat(getAllImportedInvites(guildId.toString())).isEmpty()
                 assertThat(getAllRemovedInvites(guildId.toString())).isEmpty()
             }
         }
@@ -1405,20 +1333,18 @@ class GuildCacheServiceTest {
 
             assertThat(getAllAddedInvites(guildIdString)).hasSize(1)
             assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
 
             delay(WAIT_EXPIRATION_MILLIS * 2)
             assertFalse { service.hasInvitation(guildId, entityAdd) }
 
             assertThat(getAllAddedInvites(guildIdString)).hasSize(1)
             assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
         }
 
         @Test
         fun `should return false if invitation is expired for imported guild`() = runBlocking<Unit> {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val guildIdString = guildId.toString()
             val entityAdd = getRandomString()
@@ -1426,19 +1352,17 @@ class GuildCacheServiceTest {
 
             val expiredAt = Instant.now().plusMillis(WAIT_EXPIRATION_MILLIS)
             service.addInvitation(guildId, entityAdd, expiredAt)
-            service.importInvitation(GuildInvite(guildId, entityImport, expiredAt))
+            service.addInvitation(GuildInvite(guildId, entityImport, expiredAt))
 
-            assertThat(getAllAddedInvites(guildIdString)).hasSize(1)
+            assertThat(getAllAddedInvites(guildIdString)).hasSize(2)
             assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-            assertThat(getAllImportedInvites(guildIdString)).hasSize(1)
 
             delay(WAIT_EXPIRATION_MILLIS * 2)
             assertFalse { service.hasInvitation(guildId, entityAdd) }
             assertFalse { service.hasInvitation(guildId, entityImport) }
 
-            assertThat(getAllAddedInvites(guildIdString)).hasSize(1)
+            assertThat(getAllAddedInvites(guildIdString)).hasSize(2)
             assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-            assertThat(getAllImportedInvites(guildIdString)).hasSize(1)
         }
 
         @Test
@@ -1517,13 +1441,12 @@ class GuildCacheServiceTest {
 
                 assertThat(getAllAddedMembers(guildIdString)).isEmpty()
                 assertThat(getAllRemovedMembers(guildIdString)).isEmpty()
-                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
             }
 
             @Test
             fun `should remove and mark as deleted if guild is imported`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
                 val guildId = guild.id
                 val guildIdString = guildId.toString()
                 val entityId = getRandomString()
@@ -1539,7 +1462,6 @@ class GuildCacheServiceTest {
                 assertThat(getAllRemovedMembers(guildIdString)).containsExactly(
                     entityId
                 )
-                assertThat(getAllImportedMembers(guildIdString)).isEmpty()
             }
 
             @Test
@@ -1557,7 +1479,6 @@ class GuildCacheServiceTest {
                         GuildInvite(guildId, entityId, null)
                     )
                     assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-                    assertThat(getAllImportedInvites(guildIdString)).isEmpty()
                 }
             }
 
@@ -1569,16 +1490,16 @@ class GuildCacheServiceTest {
             @Test
             fun `should return true if entity is invited in the guild`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
 
                 val guildId = guild.id
                 val guildIdString = guildId.toString()
                 val entityId = getRandomString()
 
                 val expectedInvite = GuildInvite(guildId, entityId, null)
-                service.importInvitation(expectedInvite)
+                service.addInvitation(expectedInvite)
 
-                assertThat(getAllImportedInvites(guildIdString)).containsExactly(
+                assertThat(getAllAddedInvites(guildIdString)).containsExactly(
                     expectedInvite
                 )
 
@@ -1588,13 +1509,12 @@ class GuildCacheServiceTest {
                 assertThat(getAllRemovedInvites(guildIdString)).containsExactly(
                     expectedInvite.entityId
                 )
-                assertThat(getAllImportedInvites(guildIdString)).isEmpty()
             }
 
             @Test
             fun `should return false if another entity is invited in the guild`() = runTest {
                 val guild = Guild(0, getRandomString(), getRandomString())
-                service.importGuild(guild)
+                service.addGuild(guild)
 
                 val guildId = guild.id
                 val guildIdString = guildId.toString()
@@ -1602,13 +1522,12 @@ class GuildCacheServiceTest {
                 val entityId2 = getRandomString()
 
                 val expectedInvite = GuildInvite(guildId, entityId, null)
-                service.importInvitation(expectedInvite)
+                service.addInvitation(expectedInvite)
 
                 assertFalse { service.removeInvitation(guildId, entityId2) }
 
-                assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+                assertThat(getAllAddedInvites(guildIdString)).containsExactly(expectedInvite)
                 assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-                assertThat(getAllImportedInvites(guildIdString)).containsExactly(expectedInvite)
             }
 
         }
@@ -1616,7 +1535,7 @@ class GuildCacheServiceTest {
         @Test
         fun `should return false if entity is not invited`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val guildIdString = guildId.toString()
             val entityId = getRandomString()
@@ -1624,7 +1543,6 @@ class GuildCacheServiceTest {
 
             assertThat(getAllAddedInvites(guildIdString)).isEmpty()
             assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
-            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
         }
 
         @Test
@@ -1691,9 +1609,9 @@ class GuildCacheServiceTest {
         @Test
         fun `should return empty list when an entity is member but not invited`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             service.addMember(guild.id, getRandomString())
-            service.importMember(GuildMember(guild.id, getRandomString()))
+            service.addMember(GuildMember(guild.id, getRandomString()))
 
             val invitations = service.getInvitations(guild.id).toList()
             assertThat(invitations).isEmpty()
@@ -1723,10 +1641,10 @@ class GuildCacheServiceTest {
         @ValueSource(ints = [1, 2, 3, 4, 5])
         fun `should return imported invitations`(number: Int) = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val expectedInvites = List(number) { GuildInvite(guildId, getRandomString(), null) }
-            expectedInvites.forEach { service.importInvitation(it) }
+            expectedInvites.forEach { service.addInvitation(it) }
 
             val invites = service.getInvitations(guildId).toList()
             assertThat(invites).containsExactlyInAnyOrderElementsOf(expectedInvites)
@@ -1754,10 +1672,10 @@ class GuildCacheServiceTest {
         @ValueSource(ints = [1, 2, 3, 4, 5])
         fun `should ignore the deleted invitations`(number: Int) = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val invites = List(number) { GuildInvite(guildId, getRandomString(), null) }
-            invites.forEach { service.importInvitation(it) }
+            invites.forEach { service.addInvitation(it) }
 
             invites.forEach { invite ->
                 service.removeInvitation(guildId, invite.entityId)
@@ -1771,11 +1689,11 @@ class GuildCacheServiceTest {
         @ValueSource(ints = [1, 2, 3, 4, 5])
         fun `should return the imported and added invitations`(number: Int) = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
 
             val importedInvites = List(number) { GuildInvite(guildId, getRandomString(), null) }
-            importedInvites.forEach { service.importInvitation(it) }
+            importedInvites.forEach { service.addInvitation(it) }
 
             val addedInvites = List(number) { GuildInvite(guildId, getRandomString(), null) }.onEach { invite ->
                 service.addInvitation(guildId, invite.entityId, null)
@@ -1788,7 +1706,7 @@ class GuildCacheServiceTest {
         @Test
         fun `should filter out the expired invitations for cache guild`() = runBlocking {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
 
             val invitesNotExpired = listOf(
                 GuildInvite(guild.id, getRandomString(), null),
@@ -1805,21 +1723,19 @@ class GuildCacheServiceTest {
             delay(WAIT_EXPIRATION_MILLIS * 2)
 
             assertThat(getAllAddedInvites(guild.id.toString())).hasSize(4)
-            assertThat(getAllImportedInvites(guild.id.toString())).isEmpty()
             assertThat(getAllRemovedInvites(guild.id.toString())).isEmpty()
 
             val invitesService = service.getInvitations(guild.id).map(GuildInvite::defaultTime).toList()
             assertThat(invitesService).containsExactlyInAnyOrderElementsOf(invitesNotExpired)
 
             assertThat(getAllAddedInvites(guild.id.toString())).hasSize(4)
-            assertThat(getAllImportedInvites(guild.id.toString())).isEmpty()
             assertThat(getAllRemovedInvites(guild.id.toString())).isEmpty()
         }
 
         @Test
         fun `should filter out the expired invitations for imported guild`() = runBlocking {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
 
             val invitesNotExpired = listOf(
                 GuildInvite(guild.id, getRandomString(), null),
@@ -1833,19 +1749,17 @@ class GuildCacheServiceTest {
             )
             val (expiredAt, expiredAt2) = invitesExpired
             service.addInvitation(expiredAt.guildId, expiredAt.entityId, expiredAt.expiredAt)
-            service.importInvitation(expiredAt2)
+            service.addInvitation(expiredAt2)
 
             delay(WAIT_EXPIRATION_MILLIS * 2)
 
-            assertThat(getAllAddedInvites(guild.id.toString())).hasSize(3)
-            assertThat(getAllImportedInvites(guild.id.toString())).hasSize(1)
+            assertThat(getAllAddedInvites(guild.id.toString())).hasSize(4)
             assertThat(getAllRemovedInvites(guild.id.toString())).isEmpty()
 
             val invitesService = service.getInvitations(guild.id).map(GuildInvite::defaultTime).toList()
             assertThat(invitesService).containsExactlyInAnyOrderElementsOf(invitesNotExpired)
 
-            assertThat(getAllAddedInvites(guild.id.toString())).hasSize(3)
-            assertThat(getAllImportedInvites(guild.id.toString())).hasSize(1)
+            assertThat(getAllAddedInvites(guild.id.toString())).hasSize(4)
             assertThat(getAllRemovedInvites(guild.id.toString())).isEmpty()
         }
     }
@@ -1856,17 +1770,17 @@ class GuildCacheServiceTest {
         @Test
         fun `should keep integrity of invitation data`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
 
             val now = Instant.now()
             val expiredAt = now.plusSeconds(10).truncatedTo(ChronoUnit.MILLIS)
             val createdAt = now.minusSeconds(10).truncatedTo(ChronoUnit.MILLIS)
             val invite = GuildInvite(guildId, getRandomString(), expiredAt, createdAt)
-            service.importInvitation(invite)
+            service.addInvitation(invite)
 
             val guildIdString = guildId.toString()
-            val importedInvites = getAllImportedInvites(guildIdString)
+            val importedInvites = getAllAddedInvites(guildIdString)
             assertThat(importedInvites).containsExactly(invite)
         }
 
@@ -1876,44 +1790,41 @@ class GuildCacheServiceTest {
 
             val invite = GuildInvite(guildId, getRandomString(), null)
             assertThrows<GuildNotFoundException> {
-                service.importInvitation(invite)
+                service.addInvitation(invite)
             }
 
-            assertThat(getAllImportedInvites(guildId.toString())).isEmpty()
             assertThat(getAllAddedInvites(guildId.toString())).isEmpty()
         }
 
         @Test
         fun `should throw exception if entity is member`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val invite = GuildInvite(guildId, getRandomString(), null)
 
             service.addMember(guildId, invite.entityId)
 
             assertThrows<GuildInvitedIsAlreadyMemberException> {
-                service.importInvitation(invite)
+                service.addInvitation(invite)
             }
 
             val guildIdString = guildId.toString()
-            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
             assertThat(getAllAddedInvites(guildIdString)).isEmpty()
         }
 
         @Test
         fun `should throw exception if the owner is invited`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val invite = GuildInvite(guildId, guild.ownerId, null)
 
             assertThrows<GuildInvitedIsAlreadyMemberException> {
-                service.importInvitation(invite)
+                service.addInvitation(invite)
             }
 
             val guildIdString = guildId.toString()
-            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
             assertThat(getAllAddedInvites(guildIdString)).isEmpty()
         }
 
@@ -1924,18 +1835,17 @@ class GuildCacheServiceTest {
             val invite = GuildInvite(guildId, getRandomString(), Instant.now().minusSeconds(1))
 
             assertThrows<IllegalArgumentException> {
-                service.importInvitation(invite)
+                service.addInvitation(invite)
             }
 
             val guildIdString = guildId.toString()
-            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
             assertThat(getAllAddedInvites(guildIdString)).isEmpty()
         }
 
         @Test
-        fun `should filter out invitation marked as deleted`() = runTest {
+        fun `should add invitation marked as deleted`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val guildIdString = guildId.toString()
 
@@ -1944,64 +1854,42 @@ class GuildCacheServiceTest {
             service.addInvitation(guildId, invite.entityId, invite.expiredAt)
             assertTrue { service.removeInvitation(guildId, invite.entityId) }
             assertThat(getAllRemovedInvites(guildIdString)).containsExactly(invite.entityId)
-            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
             assertThat(getAllAddedInvites(guildIdString)).isEmpty()
 
-            assertFalse { service.importInvitation(invite) }
-            assertThat(getAllRemovedInvites(guildIdString)).containsExactly(invite.entityId)
-            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
-            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
-        }
-
-        @Test
-        fun `should set as imported the added invitation`() = runTest {
-            val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
-            val guildId = guild.id
-            val guildIdString = guildId.toString()
-
-            val invite = GuildInvite(guildId, getRandomString(), null)
-            assertTrue { service.addInvitation(invite.guildId, invite.entityId, invite.expiredAt) }
-            assertThat(getAllImportedInvites(guildIdString)).isEmpty()
+            assertTrue { service.addInvitation(invite) }
+            assertThat(getAllRemovedInvites(guildIdString)).isEmpty()
             assertThat(getAllAddedInvites(guildIdString)).containsExactly(invite)
-
-            assertTrue { service.importInvitation(invite) }
-
-            assertThat(getAllImportedInvites(guildIdString)).containsExactly(invite)
-            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
         }
 
         @Test
         fun `should return true when invitations are updated`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val guildIdString = guildId.toString()
 
             val invite = GuildInvite(guildId, getRandomString(), null)
-            assertTrue { service.importInvitation(invite) }
+            assertTrue { service.addInvitation(invite) }
 
-            assertThat(getAllImportedInvites(guildIdString)).containsExactly(invite)
+            assertThat(getAllAddedInvites(guildIdString)).containsExactly(invite)
 
             val newInvite = invite.copy(expiredAt = Instant.now().plusSeconds(1).truncatedTo(ChronoUnit.MILLIS))
-            assertTrue { service.importInvitation(newInvite) }
+            assertTrue { service.addInvitation(newInvite) }
 
-            assertThat(getAllImportedInvites(guildIdString)).containsExactly(newInvite)
-            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+            assertThat(getAllAddedInvites(guildIdString)).containsExactly(newInvite)
         }
 
         @Test
         fun `should return false when invitations are already imported with the same values`() = runTest {
             val guild = Guild(0, getRandomString(), getRandomString())
-            service.importGuild(guild)
+            service.addGuild(guild)
             val guildId = guild.id
             val guildIdString = guildId.toString()
 
             val invite = GuildInvite(guildId, getRandomString(), null)
-            assertTrue { service.importInvitation(invite) }
-            assertFalse { service.importInvitation(invite) }
-            assertThat(getAllImportedInvites(guildIdString)).containsExactly(invite)
-            assertThat(getAllAddedInvites(guildIdString)).isEmpty()
+            assertTrue { service.addInvitation(invite) }
+            assertFalse { service.addInvitation(invite) }
+            assertThat(getAllAddedInvites(guildIdString)).containsExactly(invite)
         }
 
         @Test
@@ -2010,16 +1898,8 @@ class GuildCacheServiceTest {
             val guildId = guild.id
 
             assertThrows<IllegalArgumentException> {
-                service.importInvitation(GuildInvite(guildId, getRandomString(), null))
+                service.addInvitation(GuildInvite(guildId, getRandomString(), null))
             }
-        }
-    }
-
-    private suspend fun getAllImportedGuilds(): List<Guild> {
-        return getAllDataFromKey(GuildCacheService.Type.IMPORT_GUILD, "*").filter {
-            it.key.decodeToString().endsWith(GuildCacheService.Type.IMPORT_GUILD.key)
-        }.map { keyValue ->
-            cacheClient.binaryFormat.decodeFromByteArray(Guild.serializer(), keyValue.value)
         }
     }
 
@@ -2038,13 +1918,6 @@ class GuildCacheServiceTest {
                 cacheClient.binaryFormat.decodeFromByteArray(Int.serializer(), value)
             }.toList()
         }
-    }
-
-    private suspend fun getAllImportedInvites(guildId: String): List<GuildInvite> {
-        return getAllMapValues(GuildCacheService.Type.IMPORT_INVITATION, guildId)
-            .map { keyValue ->
-                cacheClient.binaryFormat.decodeFromByteArray(GuildInvite.serializer(), keyValue.value)
-            }.toList()
     }
 
     private suspend fun getAllAddedInvites(guildId: String): List<GuildInvite> {
@@ -2068,13 +1941,6 @@ class GuildCacheServiceTest {
         return getAllValuesOfSet(GuildCacheService.Type.REMOVE_INVITATION, guildId).map {
             cacheClient.binaryFormat.decodeFromByteArray(String.serializer(), it)
         }
-    }
-
-    private suspend fun getAllImportedMembers(guildId: String): List<GuildMember> {
-        return getAllMapValues(GuildCacheService.Type.IMPORT_MEMBER, guildId)
-            .map { keyValue ->
-                cacheClient.binaryFormat.decodeFromByteArray(GuildMember.serializer(), keyValue.value)
-            }.toList()
     }
 
     private suspend fun getAllAddedMembers(guildId: String): List<GuildMember> {
@@ -2116,7 +1982,7 @@ class GuildCacheServiceTest {
         crossinline block: suspend (Guild) -> Unit
     ) {
         var guild = Guild(0, getRandomString(), getRandomString())
-        service.importGuild(guild)
+        service.addGuild(guild)
         block(guild)
 
         cacheClient.connect {

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -3,11 +3,13 @@ package com.github.rushyverse.core.data.guild
 import com.github.rushyverse.core.cache.CacheClient
 import com.github.rushyverse.core.container.createRedisContainer
 import com.github.rushyverse.core.data.*
+import com.github.rushyverse.core.supplier.database.IDatabaseEntitySupplier
 import com.github.rushyverse.core.utils.getRandomString
 import io.lettuce.core.FlushMode
 import io.lettuce.core.KeyScanArgs
 import io.lettuce.core.KeyValue
 import io.lettuce.core.RedisURI
+import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
@@ -72,6 +74,81 @@ class GuildCacheServiceTest {
             assertNull(service.expirationKey)
         }
 
+    }
+
+    @Nested
+    inner class Merge {
+
+        private lateinit var supplier: IDatabaseEntitySupplier
+
+        @BeforeTest
+        fun onBefore() {
+            supplier = mockk()
+        }
+
+        @Nested
+        inner class WithCacheGuild {
+
+            @Test
+            fun `should create guild`() = runTest {
+                TODO()
+            }
+
+            @Test
+            fun `should not remove member and invitation`() = runTest {
+                TODO()
+            }
+        }
+
+        @Nested
+        inner class WithImportedGuild {
+
+            @Test
+            fun `should not create guild`() = runTest {
+                TODO()
+            }
+
+            @Test
+            fun `should remove member and invitation`() = runTest {
+                TODO()
+            }
+
+            @Test
+            fun `should continue remove member if an exception occurred`() = runTest {
+                TODO()
+            }
+
+            @Test
+            fun `should continue remove invitation if an exception occurred`() = runTest {
+                TODO()
+            }
+
+            @Test
+            fun `should not import expired invitation`() = runTest {
+                TODO()
+            }
+
+        }
+
+        @Test
+        fun `should send nothing if no guilds`() = runTest {
+            service.merge(supplier)
+        }
+
+        @Test
+        fun `should add member and invitation`() = runTest {
+            TODO()
+        }
+
+        @Test
+        fun `should continue add member if an exception occurred`() = runTest {
+            TODO()
+        }
+
+        @Test
+        fun `should continue add invitation if an exception occurred`() = runTest {
+            TODO()
+        }
     }
 
     @Nested

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildCacheServiceTest.kt
@@ -208,31 +208,34 @@ class GuildCacheServiceTest {
 
         @Test
         fun `should delete invitation for several guilds`() = runBlocking {
-//            val guild = service.createGuild(getRandomString(), getRandomString())
-//            val guild2 = service.createGuild(getRandomString(), getRandomString())
-//            val invitations1 = List(2) { getRandomString() }
-//            val invitations2 = List(2) { getRandomString() }
-//
-//            val seconds = 1L
-//            val expirationDate = Instant.now().plusSeconds(seconds)
-//
-//            invitations1.forEach {
-//                service.addInvitation(guild.id, it, expirationDate)
-//            }
-//
-//            invitations2.forEach {
-//                service.addInvitation(guild2.id, it, expirationDate)
-//            }
-//
-//            delay(seconds.seconds)
-//
-//            getAllInvites().forEach {
-//                println(it)
-//            }
-//            assertEquals(4, service.deleteExpiredInvitations())
-//
-//            val invites = getAllInvites()
-//            assertThat(invites).isEmpty()
+            val guild = Guild(0, getRandomString(), getRandomString())
+            service.addGuild(guild)
+
+            val guild2 = service.createGuild(getRandomString(), getRandomString())
+            val invitations1 = List(2) { getRandomString() }
+            val invitations2 = List(2) { getRandomString() }
+
+            val seconds = 1L
+            val expirationDate = Instant.now().plusSeconds(seconds)
+
+            invitations1.forEach {
+                service.addInvitation(guild.id, it, expirationDate)
+            }
+
+            invitations2.forEach {
+                service.addInvitation(guild2.id, it, expirationDate)
+            }
+
+            delay(seconds.seconds)
+            assertEquals(4, service.deleteExpiredInvitations())
+
+            assertThat(getAllAddedInvites(guild.id.toString())).isEmpty()
+            assertThat(getAllRemovedInvites(guild.id.toString())).containsExactlyInAnyOrderElementsOf(
+                invitations1
+            )
+
+            assertThat(getAllAddedInvites(guild2.id.toString())).isEmpty()
+            assertThat(getAllRemovedInvites(guild2.id.toString())).isEmpty()
         }
 
     }

--- a/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildDatabaseServiceTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/data/guild/GuildDatabaseServiceTest.kt
@@ -156,9 +156,6 @@ class GuildDatabaseServiceTest {
 
             delay(seconds.seconds)
 
-            getAllInvites().forEach {
-                println(it)
-            }
             assertEquals(4, service.deleteExpiredInvitations())
 
             val invites = getAllInvites()

--- a/src/test/kotlin/com/github/rushyverse/core/extension/FlowExtTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/extension/FlowExtTest.kt
@@ -1,0 +1,38 @@
+package com.github.rushyverse.core.extension
+
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import kotlin.test.Test
+
+class FlowExtTest {
+
+    @Nested
+    inner class SafeCollect {
+
+        @Test
+        fun `should not throw exception`() = runTest {
+            val expectedList = listOf(1, 2, 3)
+            val flow = expectedList.asFlow()
+            val collected = mutableListOf<Int>()
+            flow.safeCollect {
+                collected.add(it)
+                error("test")
+            }
+            assertThat(collected).containsExactlyInAnyOrderElementsOf(expectedList)
+        }
+
+        @Test
+        fun `should do nothing if flow is empty`() = runTest {
+            val flow = flowOf<Int>()
+            val collected = mutableListOf<Int>()
+            flow.safeCollect {
+                collected.add(it)
+            }
+            assertThat(collected).isEmpty()
+        }
+
+    }
+}

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseCacheEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseCacheEntitySupplierTest.kt
@@ -387,6 +387,25 @@ class DatabaseCacheEntitySupplierTest {
     inner class GuildTest {
 
         @Nested
+        inner class DeleteExpiredInvitations {
+
+            @Test
+            fun `should delete in supplier`() = runTest {
+                coEvery { guildCacheService.deleteExpiredInvitations() } returns 0
+                cacheEntitySupplier.deleteExpiredInvitations()
+                coVerify(exactly = 1) { guildCacheService.deleteExpiredInvitations() }
+            }
+
+            @ParameterizedTest
+            @ValueSource(longs = [Long.MIN_VALUE, -10, 0, 1, 5, 42, Long.MAX_VALUE])
+            fun `should return the supplier result`(result: Long) = runTest {
+                coEvery { guildCacheService.deleteExpiredInvitations() } returns result
+                assertEquals(result, cacheEntitySupplier.deleteExpiredInvitations())
+            }
+
+        }
+
+        @Nested
         inner class CreateGuild {
 
             @Test

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseEntitySupplierTest.kt
@@ -315,6 +315,25 @@ class DatabaseEntitySupplierTest {
     inner class GuildTest {
 
         @Nested
+        inner class DeleteExpiredInvitations {
+
+            @Test
+            fun `should delete in supplier`() = runTest {
+                coEvery { guildDatabaseService.deleteExpiredInvitations() } returns 0
+                databaseEntitySupplier.deleteExpiredInvitations()
+                coVerify(exactly = 1) { guildDatabaseService.deleteExpiredInvitations() }
+            }
+
+            @ParameterizedTest
+            @ValueSource(longs = [Long.MIN_VALUE, -10, 0, 1, 5, 42, Long.MAX_VALUE])
+            fun `should return the supplier result`(result: Long) = runTest {
+                coEvery { guildDatabaseService.deleteExpiredInvitations() } returns result
+                assertEquals(result, databaseEntitySupplier.deleteExpiredInvitations())
+            }
+
+        }
+
+        @Nested
         inner class CreateGuild {
 
             @Test

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseFallbackEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseFallbackEntitySupplierTest.kt
@@ -298,6 +298,26 @@ class DatabaseFallbackEntitySupplierTest {
     inner class GuildTest {
 
         @Nested
+        inner class DeleteExpiredInvitations {
+
+            @Test
+            fun `should invoke setPriority supplier first and not getPriority`() = runTest {
+                coEvery { setPrioritySupplier.deleteExpiredInvitations() } returns 0
+                fallbackEntitySupplier.deleteExpiredInvitations()
+                coVerify(exactly = 1) { setPrioritySupplier.deleteExpiredInvitations() }
+                coVerify(exactly = 0) { getPrioritySupplier.deleteExpiredInvitations() }
+            }
+
+            @ParameterizedTest
+            @ValueSource(longs = [Long.MIN_VALUE, -10, 0, 1, 5, 42, Long.MAX_VALUE])
+            fun `should return the supplier result`(result: Long) = runTest {
+                coEvery { setPrioritySupplier.deleteExpiredInvitations() } returns result
+                assertEquals(result, fallbackEntitySupplier.deleteExpiredInvitations())
+            }
+
+        }
+
+        @Nested
         inner class CreateGuild {
 
             @Test

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplierTest.kt
@@ -350,11 +350,11 @@ class DatabaseStoreEntitySupplierTest {
                 val guild = mockk<Guild>()
 
                 coEvery { supplier.createGuild(name, owner) } returns guild
-                coEvery { cache.importGuild(any()) } returns cacheResult
+                coEvery { cache.addGuild(any()) } returns cacheResult
 
                 assertEquals(guild, entitySupplier.createGuild(name, owner))
                 coVerify(exactly = 1) { supplier.createGuild(name, owner) }
-                coVerify(exactly = 1) { cache.importGuild(guild) }
+                coVerify(exactly = 1) { cache.addGuild(guild) }
                 coVerify(exactly = 0) { cache.createGuild(any(), any()) }
             }
         }
@@ -412,11 +412,11 @@ class DatabaseStoreEntitySupplierTest {
                 val guild = mockk<Guild>()
 
                 coEvery { supplier.getGuild(id) } returns guild
-                coEvery { cache.importGuild(guild) } returns true
+                coEvery { cache.addGuild(guild) } returns true
 
                 assertEquals(guild, entitySupplier.getGuild(id))
                 coVerify(exactly = 1) { supplier.getGuild(id) }
-                coVerify(exactly = 1) { cache.importGuild(guild) }
+                coVerify(exactly = 1) { cache.addGuild(guild) }
             }
 
             @Test
@@ -427,7 +427,7 @@ class DatabaseStoreEntitySupplierTest {
 
                 assertNull(entitySupplier.getGuild(id))
                 coVerify(exactly = 1) { supplier.getGuild(id) }
-                coVerify(exactly = 0) { cache.importGuild(any()) }
+                coVerify(exactly = 0) { cache.addGuild(any()) }
             }
         }
 
@@ -441,7 +441,7 @@ class DatabaseStoreEntitySupplierTest {
 
                 assertThat(entitySupplier.getGuild(name).toList()).isEmpty()
                 coVerify(exactly = 1) { supplier.getGuild(name) }
-                coVerify(exactly = 0) { cache.importGuild(any()) }
+                coVerify(exactly = 0) { cache.addGuild(any()) }
             }
 
             @Test
@@ -449,11 +449,11 @@ class DatabaseStoreEntitySupplierTest {
                 val name = getRandomString()
                 val guilds = List(2) { mockk<Guild>() }
                 coEvery { supplier.getGuild(name) } returns guilds.asFlow()
-                coEvery { cache.importGuild(guilds[0]) } throws Exception()
+                coEvery { cache.addGuild(guilds[0]) } throws Exception()
 
                 assertThat(entitySupplier.getGuild(name).toList()).containsExactlyElementsOf(guilds)
                 coVerify(exactly = 1) { supplier.getGuild(name) }
-                coVerify(exactly = guilds.size) { cache.importGuild(any()) }
+                coVerify(exactly = guilds.size) { cache.addGuild(any()) }
             }
 
             @Test
@@ -464,9 +464,9 @@ class DatabaseStoreEntitySupplierTest {
 
                 assertThat(entitySupplier.getGuild(name).toList()).containsExactlyElementsOf(guilds)
                 coVerify(exactly = 1) { supplier.getGuild(name) }
-                coVerify(exactly = guilds.size) { cache.importGuild(any()) }
+                coVerify(exactly = guilds.size) { cache.addGuild(any()) }
                 guilds.forEach { guild ->
-                    coVerify(exactly = 1) { cache.importGuild(guild) }
+                    coVerify(exactly = 1) { cache.addGuild(guild) }
                 }
             }
 
@@ -481,12 +481,12 @@ class DatabaseStoreEntitySupplierTest {
                     .containsExactlyElementsOf(guildsToImport)
 
                 coVerify(exactly = 1) { supplier.getGuild(name) }
-                coVerify(exactly = guildsToImport.size) { cache.importGuild(any()) }
+                coVerify(exactly = guildsToImport.size) { cache.addGuild(any()) }
                 guildsToImport.forEach { guild ->
-                    coVerify(exactly = 1) { cache.importGuild(guild) }
+                    coVerify(exactly = 1) { cache.addGuild(guild) }
                 }
                 guilds.drop(guildsToImport.size).forEach { guild ->
-                    coVerify(exactly = 0) { cache.importGuild(guild) }
+                    coVerify(exactly = 0) { cache.addGuild(guild) }
                 }
             }
 
@@ -734,7 +734,7 @@ class DatabaseStoreEntitySupplierTest {
 
                 assertThat(entitySupplier.getMembers(id).toList()).isEmpty()
                 coVerify(exactly = 1) { supplier.getMembers(id) }
-                coVerify(exactly = 0) { cache.importMember(any()) }
+                coVerify(exactly = 0) { cache.addMember(any()) }
             }
 
             @Test
@@ -745,9 +745,9 @@ class DatabaseStoreEntitySupplierTest {
 
                 assertThat(entitySupplier.getMembers(id).toList()).containsExactlyElementsOf(members)
                 coVerify(exactly = 1) { supplier.getMembers(id) }
-                coVerify(exactly = members.size) { cache.importMember(any()) }
+                coVerify(exactly = members.size) { cache.addMember(any()) }
                 members.forEach {
-                    coVerify(exactly = 1) { cache.importMember(it) }
+                    coVerify(exactly = 1) { cache.addMember(it) }
                 }
             }
 
@@ -756,11 +756,11 @@ class DatabaseStoreEntitySupplierTest {
                 val id = Random.nextInt()
                 val members = List(2) { GuildMember(id, getRandomString()) }
                 coEvery { supplier.getMembers(id) } returns members.asFlow()
-                coEvery { cache.importMember(members[0]) } throws Exception()
+                coEvery { cache.addMember(members[0]) } throws Exception()
 
                 assertThat(entitySupplier.getMembers(id).toList()).containsExactlyElementsOf(members)
                 coVerify(exactly = 1) { supplier.getMembers(id) }
-                coVerify(exactly = members.size) { cache.importMember(any()) }
+                coVerify(exactly = members.size) { cache.addMember(any()) }
             }
 
             @Test
@@ -774,12 +774,12 @@ class DatabaseStoreEntitySupplierTest {
                     .containsExactlyElementsOf(toImport)
 
                 coVerify(exactly = 1) { supplier.getMembers(id) }
-                coVerify(exactly = toImport.size) { cache.importMember(any()) }
+                coVerify(exactly = toImport.size) { cache.addMember(any()) }
                 toImport.forEach {
-                    coVerify(exactly = 1) { cache.importMember(it) }
+                    coVerify(exactly = 1) { cache.addMember(it) }
                 }
                 members.drop(toImport.size).forEach {
-                    coVerify(exactly = 0) { cache.importMember(it) }
+                    coVerify(exactly = 0) { cache.addMember(it) }
                 }
             }
         }
@@ -794,7 +794,7 @@ class DatabaseStoreEntitySupplierTest {
 
                 assertThat(entitySupplier.getInvitations(id).toList()).isEmpty()
                 coVerify(exactly = 1) { supplier.getInvitations(id) }
-                coVerify(exactly = 0) { cache.importInvitation(any()) }
+                coVerify(exactly = 0) { cache.addInvitation(any()) }
             }
 
             @Test
@@ -802,11 +802,11 @@ class DatabaseStoreEntitySupplierTest {
                 val id = Random.nextInt()
                 val invites = List(2) { mockk<GuildInvite>() }
                 coEvery { supplier.getInvitations(id) } returns invites.asFlow()
-                coEvery { cache.importInvitation(invites[0]) } throws Exception()
+                coEvery { cache.addInvitation(invites[0]) } throws Exception()
 
                 assertThat(entitySupplier.getInvitations(id).toList()).containsExactlyElementsOf(invites)
                 coVerify(exactly = 1) { supplier.getInvitations(id) }
-                coVerify(exactly = invites.size) { cache.importInvitation(any()) }
+                coVerify(exactly = invites.size) { cache.addInvitation(any()) }
             }
 
             @Test
@@ -817,9 +817,9 @@ class DatabaseStoreEntitySupplierTest {
 
                 assertThat(entitySupplier.getInvitations(id).toList()).containsExactlyElementsOf(invites)
                 coVerify(exactly = 1) { supplier.getInvitations(id) }
-                coVerify(exactly = invites.size) { cache.importInvitation(any()) }
+                coVerify(exactly = invites.size) { cache.addInvitation(any()) }
                 invites.forEach {
-                    coVerify(exactly = 1) { cache.importInvitation(it) }
+                    coVerify(exactly = 1) { cache.addInvitation(it) }
                 }
             }
 
@@ -834,12 +834,12 @@ class DatabaseStoreEntitySupplierTest {
                     .containsExactlyElementsOf(toImport)
 
                 coVerify(exactly = 1) { supplier.getInvitations(id) }
-                coVerify(exactly = toImport.size) { cache.importInvitation(any()) }
+                coVerify(exactly = toImport.size) { cache.addInvitation(any()) }
                 toImport.forEach {
-                    coVerify(exactly = 1) { cache.importInvitation(it) }
+                    coVerify(exactly = 1) { cache.addInvitation(it) }
                 }
                 invites.drop(toImport.size).forEach {
-                    coVerify(exactly = 0) { cache.importInvitation(it) }
+                    coVerify(exactly = 0) { cache.addInvitation(it) }
                 }
             }
 

--- a/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplierTest.kt
+++ b/src/test/kotlin/com/github/rushyverse/core/supplier/database/DatabaseStoreEntitySupplierTest.kt
@@ -340,6 +340,28 @@ class DatabaseStoreEntitySupplierTest {
     inner class GuildTest {
 
         @Nested
+        inner class DeleteExpiredInvitations {
+
+            @Test
+            fun `should delete in supplier and cache`() = runTest {
+                coEvery { cache.deleteExpiredInvitations() } returns 0
+                coEvery { supplier.deleteExpiredInvitations() } returns 0
+                entitySupplier.deleteExpiredInvitations()
+                coVerify(exactly = 1) { supplier.deleteExpiredInvitations() }
+                coVerify(exactly = 1) { cache.deleteExpiredInvitations() }
+            }
+
+            @Test
+            fun `should return addition of both`() = runTest {
+                val cacheResult = Random.nextLong()
+                val supplierResult = Random.nextLong()
+                coEvery { cache.deleteExpiredInvitations() } returns cacheResult
+                coEvery { supplier.deleteExpiredInvitations() } returns supplierResult
+                assertEquals(cacheResult + supplierResult, entitySupplier.deleteExpiredInvitations())
+            }
+        }
+
+        @Nested
         inner class CreateGuild {
 
             @ParameterizedTest


### PR DESCRIPTION
# Context

Currently, 3 data types are stored.
* Add
* Import
* Remove

However, managing three possible states is complicated and produces difficulty in understanding and working with the project.
So, the goal is to remove the Import state to only use Add and Remove