### PR TITLE
fix: Resolve jitpack publish issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,6 +130,7 @@ tasks {
     }
 
     dokkaHtml.configure {
+        // CompileJava should be executed to build library in Jitpack
         dependsOn(deleteDokkaOutputDir, compileJava.get())
         outputDirectory.set(file(dokkaOutputDir))
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,7 +130,7 @@ tasks {
     }
 
     dokkaHtml.configure {
-        dependsOn(deleteDokkaOutputDir)
+        dependsOn(deleteDokkaOutputDir, compileJava.get())
         outputDirectory.set(file(dokkaOutputDir))
     }
 }


### PR DESCRIPTION
# Context

Jitpack throws the following error : 

```
Running: ./gradlew clean -Pgroup=com.github.Rushyverse -Pversion=84909e8575 -xtest assemble publishToMavenLocal
> Task :clean UP-TO-DATE
> Task :generatePomFileForCorePublication
> Task :kspKotlin
> Task :processResources
> Task :sourcesJar

> Task :compileKotlin
...

> Task :compileJava NO-SOURCE
> Task :classes
> Task :jar
> Task :assemble
> Task :generateMetadataFileForCorePublication
> Task :deleteDokkaOutputDirectory UP-TO-DATE
> Task :dokkaHtml FAILED
10 actionable tasks: 8 executed, 2 up-to-date
Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Dhttps.protocols=TLSv1.2

FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':dokkaHtml' (type 'DokkaTask').
  - Gradle detected a problem with the following location: '/home/jitpack/build/build/generated'.
    
    Reason: Task ':dokkaHtml' uses this output of task ':compileJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':compileJava' as an input of ':dokkaHtml'.
      2. Declare an explicit dependency on ':compileJava' from ':dokkaHtml' using Task#dependsOn.
      3. Declare an explicit dependency on ':compileJava' from ':dokkaHtml' using Task#mustRunAfter.
    
    Please refer to https://docs.gradle.org/8.0.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 25s
```

# TO DO

- [x] Change gradle configuration
- [x] Check if publish works ([Log build](https://jitpack.io/com/github/Rushyverse/core/fix~publish_jitpack-029408cbc2-1/build.log))