### PR TITLE
chore(friend): Extract table creation in SQL file

### DIFF
--- a/src/main/kotlin/com/github/rushyverse/core/data/Friend.kt
+++ b/src/main/kotlin/com/github/rushyverse/core/data/Friend.kt
@@ -181,34 +181,6 @@ public data class Friend(
     val pending: Boolean,
 ) {
 
-    public companion object {
-
-        /**
-         * Create the table in database.
-         * @param database Database to create the table in.
-         */
-        public suspend fun createTable(database: R2dbcDatabase) {
-            val meta = _Friend.friend
-            val uuid = meta.uuid
-            val tableName = meta.tableName()
-            val uuid1Name = uuid.uuid1.name
-            val uuid2Name = uuid.uuid2.name
-
-            database.withTransaction {
-                database.runQuery(QueryDsl.create(meta))
-                database.runQuery(
-                    QueryDsl.executeScript(
-                        """
-                        CREATE UNIQUE INDEX ${tableName}_unique_idx
-                        ON $tableName (GREATEST($uuid1Name, $uuid2Name), LEAST($uuid1Name, $uuid2Name));
-                    """.trimIndent()
-                    )
-                )
-            }
-        }
-
-    }
-
     /**
      * First entity ID.
      */

--- a/src/main/resources/sql/friend.sql
+++ b/src/main/resources/sql/friend.sql
@@ -1,0 +1,12 @@
+-- Create table to store friends
+CREATE TABLE friend
+(
+    uuid1 uuid NOT NULL,
+    uuid2 uuid NOT NULL,
+    pending BOOLEAN NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (uuid1, uuid2)
+);
+
+-- Add index on uuid1 and uuid2 to be able to search friends by uuid
+-- and avoid duplicate entries (uuid1, uuid2) and (uuid2, uuid1)
+CREATE UNIQUE INDEX friend_unique_idx ON friend (GREATEST(uuid1, uuid2), LEAST(uuid1, uuid2));


### PR DESCRIPTION
The Guild table has a dedicated file for table creation.
To simplify the use of the library (and avoid to look the code to know how to create the table), the creation of the Friend table is moved into a SQL file